### PR TITLE
Add transparent image fallback

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -56,6 +56,8 @@ or even an static image:
 
 e.g., https://unavatar.io/github/37t?fallback=https://avatars.githubusercontent.com/u/66378906?v=4
 
+Passing `fallback=transparent` will return a transparent, base64 encoded 1x1 pixel GIF. This can be useful when you want to use your own background colour or image as a fallback.
+
 You can pass `fallback=false` for explicitly disable this behavior. In that case, a *404 Not Found* HTTP status code will returned when is not possible to get the user avatar.
 
 ### JSON

--- a/src/avatar/resolve.js
+++ b/src/avatar/resolve.js
@@ -50,6 +50,7 @@ const getDefaultFallbackUrl = ({ protocol, host }) =>
 const getFallbackUrl = memoizeOne(async ({ query, protocol, host }) => {
   const { fallback } = query
   if (fallback === false) return null
+  if (fallback === 'transparent') return 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
   if (!isUrlHttp(fallback) || !isAbsoluteUrl(fallback)) {
     return getDefaultFallbackUrl({ protocol, host })
   }


### PR DESCRIPTION
Thanks for the great work! 

This PR allows `fallback=transparent` that returns a transparent, base64 encoded 1x1 pixel GIF. This can be useful when you want to use your own background colour or image as a fallback.