### PR TITLE
fix: resolve ReDoS vulnerability in url-regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "top-user-agents": "~2.1.72",
     "ua-hints": "~1.0.1",
     "unique-random-array": "~2.0.0",
-    "url-regex": "~5.0.0"
+    "url-regex-safe": "~4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "latest",

--- a/src/avatar/auto.js
+++ b/src/avatar/auto.js
@@ -4,7 +4,7 @@ const isAbsoluteUrl = require('is-absolute-url')
 const dataUriRegex = require('data-uri-regex')
 const isEmail = require('is-email-like')
 const pTimeout = require('p-timeout')
-const urlRegex = require('url-regex')
+const urlRegex = require('url-regex-safe')
 const pAny = require('p-any')
 
 const { providers, providersBy } = require('../providers')


### PR DESCRIPTION
Replaces vulnerable `url-regex` package with `url-regex-safe` to address CVE-2020-7661 (GHSA-v4hv-rgfq-gp49). The url-regex package has no patch available for the ReDoS vulnerability, and url-regex-safe provides the same functionality with a secure implementation using re2.

Verified that the vulnerability is fixed by running yarn audit before and after the change.