### PR TITLE
perf: prevent debug when disabled

### DIFF
--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -72,22 +72,26 @@ module.exports = ({ PROXY_TIMEOUT, DEBUG_HTML_TO_FILE, getHTML }) => {
       const getResult = async ($, statusCode, log, tier) => {
         const result = getter($)
         if (typeof result !== 'string' || result === '') {
-          const { html, ...htmlDebugInfo } = await getHtmlDebugInfo($)
-          const requestId = typeof res.getHeader === 'function'
-            ? res.getHeader('x-request-id')
-            : undefined
-          const htmlFile = await writeHtmlDebugFile({
-            debugEnabled: DEBUG_HTML_TO_FILE,
-            provider: name,
-            tier,
-            requestId,
-            html
-          }).catch(() => undefined)
+          let htmlDebugInfo = {}
+
+          if (DEBUG_HTML_TO_FILE) {
+            const { html, ...info } = await getHtmlDebugInfo($)
+            const requestId = typeof res.getHeader === 'function'
+              ? res.getHeader('x-request-id')
+              : undefined
+            const htmlFile = await writeHtmlDebugFile({
+              debugEnabled: true,
+              provider: name,
+              tier,
+              requestId,
+              html
+            }).catch(() => undefined)
+            htmlDebugInfo = { ...info, ...(htmlFile ? { htmlFile } : {}) }
+          }
 
           log.error({
             statusCode,
-            ...htmlDebugInfo,
-            ...(htmlFile ? { htmlFile } : {})
+            ...htmlDebugInfo
           })
 
           throw createEmptyProviderValueError({ provider: name, statusCode })

--- a/test/unit/util/html-provider.js
+++ b/test/unit/util/html-provider.js
@@ -362,7 +362,7 @@ test('createHtmlProvider retries residential when datacenter returns 429', async
   t.true(setHeader.calledWith('x-proxy-tier', 'residential'))
 })
 
-test('createHtmlProvider logs html debug info when result is empty', async t => {
+test('createHtmlProvider logs html debug info when result is empty and debug enabled', async t => {
   const debugError = sinon.stub()
   const debugLog = sinon.stub()
   const debug = Object.assign(debugLog, {
@@ -376,6 +376,51 @@ test('createHtmlProvider logs html debug info when result is empty', async t => 
   })
   const $ = cheerio.load(
     '<html><head><title>Test Profile</title><meta property="og:image" content="https://cdn.example.com/avatar.png" /></head><body><h1>Blocked</h1></body></html>'
+  )
+
+  const { createHtmlProvider } = proxyquire('../../../src/util/html-provider', {
+    'debug-logfmt': () => debug
+  })({
+    PROXY_TIMEOUT: 8000,
+    DEBUG_HTML_TO_FILE: true,
+    getHTML: sinon.stub().resolves({ $, statusCode: 200 })
+  })
+
+  const provider = createHtmlProvider({
+    name: 'test-provider',
+    url: () => 'https://www.reddit.com/user/kikobeats/',
+    getter: () => undefined
+  })
+
+  await runProvider(provider)
+
+  t.true(
+    debugError.calledWithMatch(
+      sinon.match({
+        tier: 'origin',
+        provider: 'test-provider'
+      }),
+      sinon.match(
+        value => value.status === undefined && value.statusCode === 200 && value.htmlLength > 0
+      )
+    )
+  )
+})
+
+test('createHtmlProvider skips html serialization when debug is disabled', async t => {
+  const debugError = sinon.stub()
+  const debugLog = sinon.stub()
+  const debug = Object.assign(debugLog, {
+    error: debugError,
+    duration: (...baseArgs) => {
+      const durationLog = (...args) => debugLog(...baseArgs, ...args)
+      durationLog.error = (...args) => debugError(...baseArgs, ...args)
+      durationLog.info = (...args) => debugLog(...baseArgs, ...args)
+      return durationLog
+    }
+  })
+  const $ = cheerio.load(
+    '<html><head><title>Test Profile</title></head><body><h1>Blocked</h1></body></html>'
   )
 
   const { createHtmlProvider } = proxyquire('../../../src/util/html-provider', {
@@ -400,7 +445,7 @@ test('createHtmlProvider logs html debug info when result is empty', async t => 
         provider: 'test-provider'
       }),
       sinon.match(
-        value => value.status === undefined && value.statusCode === 200 && value.htmlLength > 0
+        value => value.statusCode === 200 && value.htmlLength === undefined
       )
     )
   )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk performance/observability change limited to provider error logging when a getter returns an empty value. Main risk is reduced debug context if the flag is expected to populate `htmlLength` without enabling file output.
> 
> **Overview**
> Prevents costly HTML serialization and debug file handling in `createHtmlProvider` unless `DEBUG_HTML_TO_FILE` is enabled.
> 
> When a provider getter returns an empty value, the code now only collects `htmlLength` and writes an `htmlFile` (and logs those fields) behind the debug flag; tests are updated to assert the gated behavior and add coverage that serialization is skipped when the flag is off.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e671e12ff244001730cce22e62251a1e00bd94d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->