### PR TITLE
chore(patreon): support campaign markup

### DIFF
--- a/src/providers/patreon.js
+++ b/src/providers/patreon.js
@@ -2,9 +2,37 @@
 
 const { $jsonld } = require('@metascraper/helpers')
 
-module.exports = ({ createHtmlProvider }) =>
+const unescapeUnicode = str =>
+  str.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  )
+
+const getRscAvatar = $ => {
+  let url
+  $('script').each((_, el) => {
+    const text = $(el).html() || ''
+    if (!text.includes('avatarPhotoImageUrls')) return
+    const match = text.match(
+      /avatarPhotoImageUrls[\s\S]*?\\"original\\":\\"((?:[^\\"]|\\u[0-9a-fA-F]{4})+)/
+    )
+    if (match) {
+      url = unescapeUnicode(match[1])
+      return false
+    }
+  })
+  return url
+}
+
+const getAvatar = $ =>
+  $jsonld('mainEntity.image.contentUrl')($) || getRscAvatar($)
+
+const factory = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'patreon',
     url: username => `https://www.patreon.com/${username}`,
-    getter: $ => $jsonld('mainEntity.image.thumbnailUrl')($)
+    getter: getAvatar
   })
+
+factory.getAvatar = getAvatar
+
+module.exports = factory

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -118,7 +118,7 @@ test('soundcloud and substack provider options are derived from helper modules',
   })({ createHtmlProvider })
 
   t.is(patreon.url('kikobeats'), 'https://www.patreon.com/kikobeats')
-  t.is(patreon.getter({}), 'jsonld:mainEntity.image.thumbnailUrl')
+  t.is(patreon.getter({}), 'jsonld:mainEntity.image.contentUrl')
 
   const instagram = proxyquire('../../../src/providers/instagram', {
     '../util/crawler-agent': () => 'crawler-agent'

--- a/test/unit/providers/patreon.js
+++ b/test/unit/providers/patreon.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const cheerio = require('cheerio')
+const test = require('ava')
+
+const { getAvatar } = require('../../../src/providers/patreon')
+
+test('.getAvatar extracts contentUrl from JSON-LD (old layout)', t => {
+  const html = `
+    <html>
+      <head>
+        <script type="application/ld+json">{
+          "@context": "https://schema.org",
+          "@type": "ProfilePage",
+          "mainEntity": {
+            "@type": "Person",
+            "name": "Jaime",
+            "image": {
+              "@type": "ImageObject",
+              "contentUrl": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/4790824/avatar/eyJ3Ijo2MjB9/1.jpeg?token-hash=abc123",
+              "thumbnailUrl": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/4790824/avatar/eyJoIjozNjB9/1.jpeg?token-hash=def456"
+            }
+          }
+        }</script>
+      </head>
+    </html>
+  `
+
+  const $ = cheerio.load(html)
+  t.is(
+    getAvatar($),
+    'https://c10.patreonusercontent.com/4/patreon-media/p/campaign/4790824/avatar/eyJ3Ijo2MjB9/1.jpeg?token-hash=abc123'
+  )
+})
+
+test('.getAvatar prefers JSON-LD over RSC when both exist', t => {
+  const html = `
+    <html>
+      <head>
+        <script type="application/ld+json">{
+          "@context": "https://schema.org",
+          "@type": "ProfilePage",
+          "mainEntity": {
+            "@type": "Person",
+            "image": {
+              "@type": "ImageObject",
+              "contentUrl": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/123/avatar/eyJ3Ijo2MjB9/42.png?token-hash=jsonld"
+            }
+          }
+        }</script>
+      </head>
+      <body>
+        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":\{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/123/avatar/eyJxIjoxMDB9/42.png?token-hash=rsc\\"}"])</script>
+      </body>
+    </html>
+  `
+
+  const $ = cheerio.load(html)
+  t.is(
+    getAvatar($),
+    'https://c10.patreonusercontent.com/4/patreon-media/p/campaign/123/avatar/eyJ3Ijo2MjB9/42.png?token-hash=jsonld'
+  )
+})
+
+test('.getAvatar extracts original quality avatar from RSC payload (Creator World layout)', t => {
+  const html = `
+    <html>
+      <head>
+        <script type="application/ld+json"></script>
+      </head>
+      <body>
+        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":\{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJxIjoxMDB9/42.png?token-hash=orig\\u0026token-time=123\\",\\"default\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJ3Ijo2MjB9/42.png?token-hash=def620\\u0026token-time=123\\"}"])</script>
+      </body>
+    </html>
+  `
+
+  const $ = cheerio.load(html)
+  t.is(
+    getAvatar($),
+    'https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJxIjoxMDB9/42.png?token-hash=orig&token-time=123'
+  )
+})
+
+test('.getAvatar returns undefined when page has no avatar signals', t => {
+  const html = '<html><head></head><body></body></html>'
+
+  const $ = cheerio.load(html)
+  t.is(getAvatar($), undefined)
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Patreon avatar extraction logic with a new regex-based fallback over inline script payloads, which may be brittle to markup changes and could affect returned image URLs.
> 
> **Overview**
> Updates the Patreon HTML provider to fetch avatars from `mainEntity.image.contentUrl` (higher-quality) instead of `thumbnailUrl`, and adds a fallback that extracts the `avatarPhotoImageUrls.original` value from Next.js/RSC script payloads (with unicode unescaping).
> 
> Exports `getAvatar` for direct testing and adds a dedicated unit test suite covering JSON-LD extraction, JSON-LD precedence over RSC, RSC-only pages, and no-signal pages; the shared `html-config` test is updated to the new JSON-LD path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8522041e7d2438d7e5b920c50ef3797cb5bb932. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->