### PR TITLE
chore: signaling when a provider is being blocked

### DIFF
--- a/src/providers/instagram.js
+++ b/src/providers/instagram.js
@@ -2,10 +2,12 @@
 
 const randomCrawlerAgent = require('../util/crawler-agent')
 
+const isBlocked = $ => $('title').text().includes('Login')
+
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'instagram',
     url: input => `https://www.instagram.com/${input}`,
-    getter: getOgImage,
+    getter: $ => !isBlocked($) && getOgImage($),
     htmlOpts: () => ({ headers: { 'user-agent': randomCrawlerAgent() } })
   })

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -18,9 +18,21 @@ const createEmptyProviderValueError = ({ provider, statusCode }) =>
     message: 'Empty value returned by the provider.'
   })
 
+
 const getOgImage = $ => $('meta[property="og:image"]').attr('content')
 
 module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
+  /**
+   * @param {object} opts
+   * @param {string} opts.name - Provider identifier used in logs and metrics.
+   * @param {(input: string) => string | Promise<string>} opts.url - Builds the URL to fetch for a given input.
+   * @param {($: cheerio.CheerioAPI) => string | false | undefined} opts.getter
+   *   Extracts the avatar URL from the fetched HTML.
+   *   - `string`    — avatar URL found (success).
+   *   - `undefined`  — avatar not found (normal failure, no retry).
+   *   - `false`     — page is blocked; error.blocked will be set to true.
+   * @param {() => object} [opts.htmlOpts] - Returns extra options merged into the fetch call.
+   */
   const createHtmlProvider = ({ name, url, getter, htmlOpts }) => {
     const provider = async function ({ input, req = {}, res = {} }) {
       const providerUrl = await url(input)
@@ -57,8 +69,9 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             statusCode
           })
           error.html = attempt.lastHtml
+          if (result === false) error.blocked = true
 
-          log.error({ statusCode })
+          log.error({ statusCode, status: result === false ? 'blocked' : undefined })
 
           throw error
         }

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -129,3 +129,26 @@ test('soundcloud and substack provider options are derived from helper modules',
     headers: { 'user-agent': 'crawler-agent' }
   })
 })
+
+test('instagram getter returns false when title is login wall', t => {
+  const instagram = proxyquire('../../../src/providers/instagram', {
+    '../util/crawler-agent': () => 'crawler-agent'
+  })({ createHtmlProvider, getOgImage })
+
+  const $ = cheerio.load('<html><title>Login • Instagram</title></html>')
+  t.is(instagram.getter($), false)
+})
+
+test('instagram getter returns og:image URL for valid profile page', t => {
+  const instagram = proxyquire('../../../src/providers/instagram', {
+    '../util/crawler-agent': () => 'crawler-agent'
+  })({ createHtmlProvider, getOgImage })
+
+  const avatarUrl = 'https://scontent-mad2-1.cdninstagram.com/v/t51.82787-19/photo.jpg'
+  const $ = cheerio.load(
+    '<html><title>Will Smith (@willsmith) • Instagram</title>' +
+    `<meta property="og:image" content="${avatarUrl}" />` +
+    '</html>'
+  )
+  t.is(instagram.getter($), avatarUrl)
+})

--- a/test/unit/util/html-provider.js
+++ b/test/unit/util/html-provider.js
@@ -118,11 +118,35 @@ test('attempt returns NOT_FOUND symbol when status is 404 via onFetchHTML', asyn
   t.is(result, NOT_FOUND)
 })
 
-test('createHtmlProvider throws when status code is missing', async t => {
+test('createHtmlProvider throws when status code is undefined', async t => {
   const provider = createProvider({
     providerUrl: 'https://www.reddit.com/user/kikobeats/',
     getterResult: '/assets/avatar.svg',
     getHTML: async () => ({ $: {}, statusCode: undefined })
+  })
+
+  await t.throwsAsync(runProvider(provider), {
+    message: 'Empty value returned by the provider.'
+  })
+})
+
+test('createHtmlProvider throws when status code is null', async t => {
+  const provider = createProvider({
+    providerUrl: 'https://www.reddit.com/user/kikobeats/',
+    getterResult: '/assets/avatar.svg',
+    getHTML: async () => ({ $: {}, statusCode: null })
+  })
+
+  await t.throwsAsync(runProvider(provider), {
+    message: 'Empty value returned by the provider.'
+  })
+})
+
+test('createHtmlProvider throws when status code is empty string', async t => {
+  const provider = createProvider({
+    providerUrl: 'https://www.reddit.com/user/kikobeats/',
+    getterResult: '/assets/avatar.svg',
+    getHTML: async () => ({ $: {}, statusCode: '' })
   })
 
   await t.throwsAsync(runProvider(provider), {
@@ -248,6 +272,50 @@ test('createHtmlProvider attaches html to error when getter returns empty', asyn
 
   t.is(typeof error.html, 'string')
   t.true(error.html.includes('<h1>Blocked</h1>'))
+})
+
+test('createHtmlProvider sets blocked and attaches html on error when getter returns false', async t => {
+  const $ = cheerio.load('<html><title>Login • Instagram</title></html>')
+
+  const { createHtmlProvider } = require('../../../src/util/html-provider')({
+    PROXY_TIMEOUT: 8000,
+    getHTML: async () => ({ $, statusCode: 200 })
+  })
+
+  const provider = createHtmlProvider({
+    name: 'test-provider',
+    url: () => 'https://www.instagram.com/willsmith',
+    getter: () => false
+  })
+
+  const error = await t.throwsAsync(runProvider(provider), {
+    message: 'Empty value returned by the provider.'
+  })
+
+  t.true(error.blocked)
+  t.is(typeof error.html, 'string')
+  t.true(error.html.includes('Login'))
+})
+
+test('createHtmlProvider does not set blocked when getter returns undefined', async t => {
+  const $ = cheerio.load('<html><body></body></html>')
+
+  const { createHtmlProvider } = require('../../../src/util/html-provider')({
+    PROXY_TIMEOUT: 8000,
+    getHTML: async () => ({ $, statusCode: 200 })
+  })
+
+  const provider = createHtmlProvider({
+    name: 'test-provider',
+    url: () => 'https://www.instagram.com/willsmith',
+    getter: () => undefined
+  })
+
+  const error = await t.throwsAsync(runProvider(provider), {
+    message: 'Empty value returned by the provider.'
+  })
+
+  t.is(error.blocked, undefined)
 })
 
 test('module exports NOT_FOUND symbol', t => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is narrowly scoped to provider parsing and error metadata/logging; main risk is misclassifying pages as blocked or altering downstream error handling expectations.
> 
> **Overview**
> Adds an explicit **“blocked” signal** to HTML-based providers by allowing a provider `getter` to return `false`, which causes `createHtmlProvider` to throw an error with `error.blocked = true` and logs status as `blocked`.
> 
> Updates the Instagram provider to detect the login wall (title contains `Login`) and return `false` instead of attempting to read `og:image`, and expands unit tests to cover blocked vs missing results and missing `statusCode` cases (`undefined`/`null`/empty string).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0318b4b235e1e4c361eb01ee5e25a6430256ca9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->