### PR TITLE
chore: set default headers

### DIFF
--- a/src/providers/instagram.js
+++ b/src/providers/instagram.js
@@ -1,11 +1,8 @@
 'use strict'
 
-const randomCrawlerAgent = require('../util/crawler-agent')
-
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'instagram',
     url: input => `https://www.instagram.com/${input}`,
-    getter: getOgImage,
-    htmlOpts: () => ({ headers: { 'user-agent': randomCrawlerAgent() } })
+    getter: getOgImage
   })

--- a/src/providers/printables.js
+++ b/src/providers/printables.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const randomCrawlerAgent = require('../util/crawler-agent')
-
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'printables',
@@ -9,6 +7,5 @@ module.exports = ({ createHtmlProvider, getOgImage }) =>
       `https://www.printables.com/${
         input.startsWith('@') ? input : `@${input}`
       }`,
-    getter: getOgImage,
-    htmlOpts: () => ({ headers: { 'user-agent': randomCrawlerAgent() } })
+    getter: getOgImage
   })

--- a/src/providers/x.js
+++ b/src/providers/x.js
@@ -2,8 +2,6 @@
 
 const { $jsonld } = require('@metascraper/helpers')
 
-const randomCrawlerAgent = require('../util/crawler-agent')
-
 const toHighResolution = url => {
   if (url?.endsWith('_200x200.jpg')) {
     return url.replace('_200x200.jpg', '_400x400.jpg')
@@ -16,15 +14,15 @@ const toHighResolution = url => {
 
 const getProfileImage = $ =>
   toHighResolution(
-    $jsonld('mainEntity.image.contentUrl')($) || $('meta[property="og:image"]').attr('content')
+    $jsonld('mainEntity.image.contentUrl')($) ||
+      $('meta[property="og:image"]').attr('content')
   )
 
 const factory = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'x',
     url: input => `https://x.com/${input}`,
-    getter: getProfileImage,
-    htmlOpts: () => ({ headers: { 'user-agent': randomCrawlerAgent() } })
+    getter: getProfileImage
   })
 
 factory.getProfileImage = getProfileImage

--- a/src/util/crawler-agent.js
+++ b/src/util/crawler-agent.js
@@ -2,7 +2,4 @@
 
 const uniqueRandomArray = require('unique-random-array')
 
-// TODO: update top-crawler-agents to don't make necessary to filter.
-module.exports = uniqueRandomArray(
-  require('top-crawler-agents').filter(agent => agent.startsWith('Slackbot'))
-)
+module.exports = uniqueRandomArray(require('top-crawler-agents'))

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -4,6 +4,7 @@ const { normalizeUrl } = require('@metascraper/helpers')
 const debug = require('debug-logfmt')('html-provider')
 const isAntibot = require('is-antibot')
 
+const randomCrawlerAgent = require('./crawler-agent')
 const httpStatus = require('./http-status')
 const ExtendableError = require('./error')
 
@@ -43,7 +44,15 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
       const context = { provider: name, input, providerUrl }
 
       const attempt = async gotOpts => {
-        const defaultOpts = { ...htmlOpts?.(), timeout: PROXY_TIMEOUT }
+        const providerOpts = htmlOpts?.() ?? {}
+        const defaultOpts = {
+          ...providerOpts,
+          headers: {
+            'user-agent': randomCrawlerAgent(),
+            ...providerOpts.headers
+          },
+          timeout: PROXY_TIMEOUT
+        }
         const fetchOpts = gotOpts ? { ...defaultOpts, ...gotOpts } : defaultOpts
         const tier = fetchOpts.tier ?? 'origin'
 

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -94,16 +94,14 @@ test('dribbble, reddit and telegram getters read expected HTML attributes', t =>
   t.is(telegram.getter(telegramHtml), 'https://a.com/tg.png')
 })
 
-test('printables provider prepends @ and uses crawler user-agent', t => {
-  const printables = proxyquire('../../../src/providers/printables', {
-    '../util/crawler-agent': () => 'crawler-agent'
-  })({ createHtmlProvider, getOgImage })
+test('printables provider prepends @ to input', t => {
+  const printables = require('../../../src/providers/printables')({
+    createHtmlProvider,
+    getOgImage
+  })
 
   t.is(printables.url('DukeDoks'), 'https://www.printables.com/@DukeDoks')
   t.is(printables.url('@DukeDoks'), 'https://www.printables.com/@DukeDoks')
-  t.deepEqual(printables.htmlOpts(), {
-    headers: { 'user-agent': 'crawler-agent' }
-  })
 })
 
 test('soundcloud and substack provider options are derived from helper modules', t => {
@@ -133,15 +131,6 @@ test('soundcloud and substack provider options are derived from helper modules',
 
   t.is(patreon.url('kikobeats'), 'https://www.patreon.com/kikobeats')
   t.is(patreon.getter({}), 'jsonld:mainEntity.image.contentUrl')
-
-  const instagram = proxyquire('../../../src/providers/instagram', {
-    '../util/crawler-agent': () => 'crawler-agent'
-  })({ createHtmlProvider, getOgImage })
-
-  t.is(instagram.url('willsmith'), 'https://www.instagram.com/willsmith')
-  t.deepEqual(instagram.htmlOpts(), {
-    headers: { 'user-agent': 'crawler-agent' }
-  })
 })
 
 test('linkedin getter returns undefined when og:image is missing', t => {
@@ -170,18 +159,20 @@ test('linkedin getter returns og:image URL for valid profile page', t => {
 })
 
 test('instagram getter returns undefined when og:image is missing', t => {
-  const instagram = proxyquire('../../../src/providers/instagram', {
-    '../util/crawler-agent': () => 'crawler-agent'
-  })({ createHtmlProvider, getOgImage })
+  const instagram = require('../../../src/providers/instagram')({
+    createHtmlProvider,
+    getOgImage
+  })
 
   const $ = cheerio.load('<html><title>Login • Instagram</title></html>')
   t.is(instagram.getter($), undefined)
 })
 
 test('instagram getter returns og:image URL for valid profile page', t => {
-  const instagram = proxyquire('../../../src/providers/instagram', {
-    '../util/crawler-agent': () => 'crawler-agent'
-  })({ createHtmlProvider, getOgImage })
+  const instagram = require('../../../src/providers/instagram')({
+    createHtmlProvider,
+    getOgImage
+  })
 
   const avatarUrl =
     'https://scontent-mad2-1.cdninstagram.com/v/t51.82787-19/photo.jpg'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default request headers for all HTML providers, which can affect scraping success rates and trigger/avoid antibot behavior across multiple sites.
> 
> **Overview**
> Moves crawler `user-agent` handling into `createHtmlProvider` so all HTML fetches get a default random crawler UA, while still allowing providers to override/extend headers via `htmlOpts`.
> 
> Removes per-provider UA overrides from `instagram`, `printables`, and `x`, and updates `crawler-agent` to sample from all `top-crawler-agents` (no Slackbot-only filtering). Unit tests are adjusted to stop asserting provider-specific UA headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e61a8a0c95d8139ab2b3f56bccf7a05cfaab4a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->