### PR TITLE
chore(linkedin): support company avatar

### DIFF
--- a/src/providers/linkedin.js
+++ b/src/providers/linkedin.js
@@ -1,8 +1,16 @@
 'use strict'
 
+const linkedinUrl = input => {
+  const [first, second] = input.split(':')
+  const type = second ? first : 'user'
+  const id = second ?? first
+  const path = type === 'user' ? 'in' : type
+  return `https://www.linkedin.com/${path}/${id}`
+}
+
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'linkedin',
-    url: input => `https://www.linkedin.com/in/${input}`,
+    url: linkedinUrl,
     getter: getOgImage
   })

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -44,6 +44,12 @@ test('html provider modules expose expected URL builders', t => {
     getOgImage
   })
   t.is(linkedin.url('kikobeats'), 'https://www.linkedin.com/in/kikobeats')
+  t.is(linkedin.url('user:kikobeats'), 'https://www.linkedin.com/in/kikobeats')
+  t.is(
+    linkedin.url('company:unavatar'),
+    'https://www.linkedin.com/company/unavatar'
+  )
+  t.is(linkedin.url('school:mit'), 'https://www.linkedin.com/school/mit')
 
   const twitch = require('../../../src/providers/twitch')({
     createHtmlProvider,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated change to LinkedIn URL construction plus tests; low risk aside from potential edge cases in parsing unexpected `type:id` inputs.
> 
> **Overview**
> Updates the LinkedIn HTML provider to build URLs from either a plain username (defaulting to `/in/…`) or a new `type:id` format, enabling fetching avatars for entities like `company` and `school` in addition to users.
> 
> Adds unit coverage in `test/unit/providers/html-config.js` to verify URL generation for `user:`, `company:`, and `school:` inputs while preserving the existing untyped behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c62b901ef7a360c14b1531afca2ace77c7560c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->