### PR TITLE
refactor: add more tests

### DIFF
--- a/src/providers/linkedin.js
+++ b/src/providers/linkedin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const linkedinUrl = input => {
+const getAvatarUrl = input => {
   const [first, second] = input.split(':')
   const type = second ? first : 'user'
   const id = second ?? first
@@ -11,6 +11,8 @@ const linkedinUrl = input => {
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'linkedin',
-    url: linkedinUrl,
+    url: getAvatarUrl,
     getter: getOgImage
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/mastodon.js
+++ b/src/providers/mastodon.js
@@ -53,6 +53,7 @@ module.exports = ({ got, isReservedIp }) => {
     return body?.avatar
   }
 
-  mastodon.parseMastodonInput = parseMastodonInput
   return mastodon
 }
+
+module.exports.parseMastodonInput = parseMastodonInput

--- a/src/providers/onlyfans.js
+++ b/src/providers/onlyfans.js
@@ -4,8 +4,7 @@ const { get } = require('lodash')
 
 const getAvatarUrl = $ => {
   const text = $('script[type="application/ld+json"]').contents().text()
-  if (!text) return
-  return get(JSON.parse(text), 'mainEntity.image')
+  return text ? get(JSON.parse(text), 'mainEntity.image') : undefined
 }
 
 module.exports = ({ createHtmlProvider }) =>
@@ -21,3 +20,5 @@ module.exports = ({ createHtmlProvider }) =>
       }
     })
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/openstreetmap.js
+++ b/src/providers/openstreetmap.js
@@ -1,20 +1,24 @@
 'use strict'
 
+const OPENSTREETMAP_API_URL = 'https://api.openstreetmap.org/api/0.6/user'
+
 const OPENSTREETMAP_USER_ID_REGEX = /^\d+$/
 
 module.exports = ({ got, createHtmlProvider }) => {
-  const fromID = userId =>
-    got(`https://api.openstreetmap.org/api/0.6/user/${userId}.json`, {
-      responseType: 'json'
-    }).then(({ body }) => body?.user?.img?.href)
-
   const fromUsername = createHtmlProvider({
     name: 'openstreetmap',
-    url: username => `https://www.openstreetmap.org/user/${encodeURIComponent(username)}`,
+    url: username =>
+      `https://www.openstreetmap.org/user/${encodeURIComponent(username)}`,
     getter: $ => $('img.user_image').attr('src')
   })
 
-  return function openstreetmap ({ input }) {
-    return OPENSTREETMAP_USER_ID_REGEX.test(input) ? fromID(input) : fromUsername(...arguments)
+  return function openstreetmap (ctx) {
+    return OPENSTREETMAP_USER_ID_REGEX.test(ctx.input)
+      ? got(`${OPENSTREETMAP_API_URL}/${ctx.input}.json`, {
+        responseType: 'json'
+      }).then(({ body }) => body?.user?.img?.href)
+      : fromUsername(ctx)
   }
 }
+
+module.exports.OPENSTREETMAP_USER_ID_REGEX = OPENSTREETMAP_USER_ID_REGEX

--- a/src/providers/patreon.js
+++ b/src/providers/patreon.js
@@ -26,13 +26,11 @@ const getRscAvatar = $ => {
 const getAvatar = $ =>
   $jsonld('mainEntity.image.contentUrl')($) || getRscAvatar($)
 
-const factory = ({ createHtmlProvider }) =>
+module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'patreon',
     url: username => `https://www.patreon.com/${username}`,
     getter: getAvatar
   })
 
-factory.getAvatar = getAvatar
-
-module.exports = factory
+module.exports.getAvatar = getAvatar

--- a/src/providers/printables.js
+++ b/src/providers/printables.js
@@ -1,11 +1,13 @@
 'use strict'
 
+const getAvatarUrl = input =>
+  `https://www.printables.com/${input.startsWith('@') ? input : `@${input}`}`
+
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'printables',
-    url: input =>
-      `https://www.printables.com/${
-        input.startsWith('@') ? input : `@${input}`
-      }`,
+    url: getAvatarUrl,
     getter: getOgImage
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/spotify.js
+++ b/src/providers/spotify.js
@@ -1,18 +1,20 @@
 'use strict'
 
-const spotifyUri = input => {
+const getAvatarUrl = input => {
   const [first, second] = input.split(':')
   const type = second ? first : 'user'
   const id = second ?? first
-  return `${type}/${id}`
+  return `https://open.spotify.com/${type}/${id}`
 }
 
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'spotify',
-    url: input => `https://open.spotify.com/${spotifyUri(input)}`,
+    url: getAvatarUrl,
     getter: getOgImage,
     htmlOpts: () => ({
       prerender: true
     })
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/substack.js
+++ b/src/providers/substack.js
@@ -12,7 +12,9 @@ const getBestSrcsetUrl = srcset => {
   }))
 
   if (candidates.length === 0) return
-  return candidates.reduce((best, current) => (current.score > best.score ? current : best)).url
+  return candidates.reduce((best, current) =>
+    current.score > best.score ? current : best
+  ).url
 }
 
 const getPictureAvatar = $ => {
@@ -21,15 +23,14 @@ const getPictureAvatar = $ => {
   return getBestSrcsetUrl(srcset) || pictureImg.attr('src')
 }
 
-const getAvatarUrl = $ => $jsonld('publisher.logo.url')($) || getPictureAvatar($)
+const getAvatarUrl = $ =>
+  $jsonld('publisher.logo.url')($) || getPictureAvatar($)
 
-const factory = ({ createHtmlProvider }) =>
+module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'substack',
     url: input => `https://${input}.substack.com`,
     getter: getAvatarUrl
   })
 
-factory.getAvatarUrl = getAvatarUrl
-
-module.exports = factory
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/tiktok.js
+++ b/src/providers/tiktok.js
@@ -14,13 +14,11 @@ const getAvatarUrl = $ => {
   ])
 }
 
-const factory = ({ createHtmlProvider }) =>
+module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'tiktok',
     url: input => `https://www.tiktok.com/@${input}`,
     getter: getAvatarUrl
   })
 
-factory.getAvatarUrl = getAvatarUrl
-
-module.exports = factory
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/whatsapp.js
+++ b/src/providers/whatsapp.js
@@ -8,7 +8,7 @@ const whatsappURI = input => {
   }
 }
 
-const whatsappURL = input => {
+const getAvatarUrl = input => {
   const { type, id } = whatsappURI(input)
   switch (type) {
     case 'phone':
@@ -26,6 +26,8 @@ const whatsappURL = input => {
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'whatsapp',
-    url: whatsappURL,
+    url: getAvatarUrl,
     getter: getOgImage
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/x.js
+++ b/src/providers/x.js
@@ -18,13 +18,11 @@ const getProfileImage = $ =>
       $('meta[property="og:image"]').attr('content')
   )
 
-const factory = ({ createHtmlProvider }) =>
+module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'x',
     url: input => `https://x.com/${input}`,
     getter: getProfileImage
   })
 
-factory.getProfileImage = getProfileImage
-
-module.exports = factory
+module.exports.getProfileImage = getProfileImage

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -1,18 +1,22 @@
 'use strict'
 
+const getAvatarUrl = input => {
+  let path
+  if (input.startsWith('@')) {
+    path = input
+  } else if (input.startsWith('UC') && input.length === 24) {
+    path = `channel/${input}`
+  } else {
+    path = `@${input}`
+  }
+  return `https://www.youtube.com/${path}`
+}
+
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'youtube',
-    url: input => {
-      let path
-      if (input.startsWith('@')) {
-        path = input
-      } else if (input.startsWith('UC') && input.length === 24) {
-        path = `channel/${input}`
-      } else {
-        path = `@${input}`
-      }
-      return `https://www.youtube.com/${path}`
-    },
+    url: getAvatarUrl,
     getter: getOgImage
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/test/unit/providers/linkedin.js
+++ b/test/unit/providers/linkedin.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const test = require('ava')
+
+const { getAvatarUrl } = require('../../../src/providers/linkedin')
+
+test('.getAvatarUrl defaults to user profile path', t => {
+  t.is(getAvatarUrl('kikobeats'), 'https://www.linkedin.com/in/kikobeats')
+})
+
+test('.getAvatarUrl with explicit user type', t => {
+  t.is(getAvatarUrl('user:kikobeats'), 'https://www.linkedin.com/in/kikobeats')
+})
+
+test('.getAvatarUrl with company type', t => {
+  t.is(
+    getAvatarUrl('company:microlink'),
+    'https://www.linkedin.com/company/microlink'
+  )
+})
+
+test('.getAvatarUrl with school type', t => {
+  t.is(getAvatarUrl('school:mit'), 'https://www.linkedin.com/school/mit')
+})

--- a/test/unit/providers/mastodon.js
+++ b/test/unit/providers/mastodon.js
@@ -3,10 +3,7 @@
 const test = require('ava')
 const sinon = require('sinon')
 
-const { parseMastodonInput } = require('../../../src/providers/mastodon')({
-  got: () => {},
-  isReservedIp: async () => false
-})
+const { parseMastodonInput } = require('../../../src/providers/mastodon')
 
 test('parses @user@server format', t => {
   t.deepEqual(parseMastodonInput('@kiko@indieweb.social'), {

--- a/test/unit/providers/onlyfans.js
+++ b/test/unit/providers/onlyfans.js
@@ -19,12 +19,9 @@ test('onlyfans provider exposes expected URL and html opts', t => {
   })
 })
 
-test('onlyfans getter parses JSON-LD avatar URL and handles empty script payload', t => {
-  const createHtmlProvider = opts => opts
-  const provider = require('../../../src/providers/onlyfans')({
-    createHtmlProvider
-  })
+const { getAvatarUrl } = require('../../../src/providers/onlyfans')
 
+test('.getAvatarUrl parses JSON-LD avatar URL', t => {
   const html = `
     <html>
       <head>
@@ -35,8 +32,10 @@ test('onlyfans getter parses JSON-LD avatar URL and handles empty script payload
     </html>
   `
   const $ = cheerio.load(html)
-  t.is(provider.getter($), 'https://cdn.example.com/of-avatar.jpg')
+  t.is(getAvatarUrl($), 'https://cdn.example.com/of-avatar.jpg')
+})
 
-  const empty = cheerio.load('<html><head></head></html>')
-  t.is(provider.getter(empty), undefined)
+test('.getAvatarUrl returns undefined when JSON-LD script is missing', t => {
+  const $ = cheerio.load('<html><head></head></html>')
+  t.is(getAvatarUrl($), undefined)
 })

--- a/test/unit/providers/openstreetmap.js
+++ b/test/unit/providers/openstreetmap.js
@@ -2,13 +2,35 @@
 
 const test = require('ava')
 
+const {
+  OPENSTREETMAP_USER_ID_REGEX
+} = require('../../../src/providers/openstreetmap')
+
+test('OPENSTREETMAP_USER_ID_REGEX matches numeric user ids', t => {
+  t.true(OPENSTREETMAP_USER_ID_REGEX.test('98672'))
+  t.true(OPENSTREETMAP_USER_ID_REGEX.test('0'))
+  t.true(OPENSTREETMAP_USER_ID_REGEX.test('123456789'))
+})
+
+test('OPENSTREETMAP_USER_ID_REGEX rejects non-numeric input', t => {
+  t.false(OPENSTREETMAP_USER_ID_REGEX.test('Terence Eden'))
+  t.false(OPENSTREETMAP_USER_ID_REGEX.test('user123'))
+  t.false(OPENSTREETMAP_USER_ID_REGEX.test('123abc'))
+  t.false(OPENSTREETMAP_USER_ID_REGEX.test(''))
+  t.false(OPENSTREETMAP_USER_ID_REGEX.test('12.34'))
+})
+
 test('returns avatar URL for numeric user id', async t => {
   let htmlProviderCalled = false
 
   const gotStub = async (url, opts) => {
     t.is(url, 'https://api.openstreetmap.org/api/0.6/user/98672.json')
     t.is(opts.responseType, 'json')
-    return { body: { user: { img: { href: 'https://www.gravatar.com/avatar/abc.jpg?s=100' } } } }
+    return {
+      body: {
+        user: { img: { href: 'https://www.gravatar.com/avatar/abc.jpg?s=100' } }
+      }
+    }
   }
 
   const provider = require('../../../src/providers/openstreetmap')({

--- a/test/unit/providers/patreon.js
+++ b/test/unit/providers/patreon.js
@@ -50,7 +50,7 @@ test('.getAvatar prefers JSON-LD over RSC when both exist', t => {
         }</script>
       </head>
       <body>
-        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":\{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/123/avatar/eyJxIjoxMDB9/42.png?token-hash=rsc\\"}"])</script>
+        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/123/avatar/eyJxIjoxMDB9/42.png?token-hash=rsc\\"}"])</script>
       </body>
     </html>
   `
@@ -69,7 +69,7 @@ test('.getAvatar extracts original quality avatar from RSC payload (Creator Worl
         <script type="application/ld+json"></script>
       </head>
       <body>
-        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":\{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJxIjoxMDB9/42.png?token-hash=orig\\u0026token-time=123\\",\\"default\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJ3Ijo2MjB9/42.png?token-hash=def620\\u0026token-time=123\\"}"])</script>
+        <script>self.__next_f.push([1,"avatarPhotoImageUrls\\":{\\"original\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJxIjoxMDB9/42.png?token-hash=orig\\u0026token-time=123\\",\\"default\\":\\"https://c10.patreonusercontent.com/4/patreon-media/p/campaign/6934869/hash/eyJ3Ijo2MjB9/42.png?token-hash=def620\\u0026token-time=123\\"}"])</script>
       </body>
     </html>
   `

--- a/test/unit/providers/printables.js
+++ b/test/unit/providers/printables.js
@@ -3,6 +3,16 @@
 const cheerio = require('cheerio')
 const test = require('ava')
 
+const { getAvatarUrl } = require('../../../src/providers/printables')
+
+test('.getAvatarUrl prepends @ when missing', t => {
+  t.is(getAvatarUrl('kikobeats'), 'https://www.printables.com/@kikobeats')
+})
+
+test('.getAvatarUrl keeps existing @ prefix', t => {
+  t.is(getAvatarUrl('@kikobeats'), 'https://www.printables.com/@kikobeats')
+})
+
 const createHtmlProvider = opts => opts
 const getOgImage = $ =>
   $('meta[property="og:image"]').attr('content') ||
@@ -16,8 +26,8 @@ const printables = require('../../../src/providers/printables')({
 test('getter extracts og:image from name attribute', t => {
   const $ = cheerio.load(
     '<html><head>' +
-    '<meta name="og:image" content="https://media.printables.com/media/auth/avatars/cd/thumbs/cover/320x320/jpg/cd02bb1d.jpg"/>' +
-    '</head></html>'
+      '<meta name="og:image" content="https://media.printables.com/media/auth/avatars/cd/thumbs/cover/320x320/jpg/cd02bb1d.jpg"/>' +
+      '</head></html>'
   )
   t.is(
     printables.getter($),
@@ -28,8 +38,8 @@ test('getter extracts og:image from name attribute', t => {
 test('getter extracts og:image from property attribute', t => {
   const $ = cheerio.load(
     '<html><head>' +
-    '<meta property="og:image" content="https://media.printables.com/avatar.jpg"/>' +
-    '</head></html>'
+      '<meta property="og:image" content="https://media.printables.com/avatar.jpg"/>' +
+      '</head></html>'
   )
   t.is(printables.getter($), 'https://media.printables.com/avatar.jpg')
 })

--- a/test/unit/providers/spotify.js
+++ b/test/unit/providers/spotify.js
@@ -2,17 +2,25 @@
 
 const test = require('ava')
 
-test('spotify provider derives URI from usernames and typed identifiers', t => {
-  const createHtmlProvider = opts => opts
-  const provider = require('../../../src/providers/spotify')({
-    createHtmlProvider,
-    getOgImage: () => 'og-image'
-  })
+const { getAvatarUrl } = require('../../../src/providers/spotify')
 
-  t.is(provider.url('iron_maiden_'), 'https://open.spotify.com/user/iron_maiden_')
+test('.getAvatarUrl defaults to user profile path', t => {
   t.is(
-    provider.url('artist:1vCWHaC5f2uS3yhpwWbIA6'),
+    getAvatarUrl('iron_maiden_'),
+    'https://open.spotify.com/user/iron_maiden_'
+  )
+})
+
+test('.getAvatarUrl with explicit artist type', t => {
+  t.is(
+    getAvatarUrl('artist:1vCWHaC5f2uS3yhpwWbIA6'),
     'https://open.spotify.com/artist/1vCWHaC5f2uS3yhpwWbIA6'
   )
-  t.deepEqual(provider.htmlOpts(), { prerender: true })
+})
+
+test('.getAvatarUrl with explicit playlist type', t => {
+  t.is(
+    getAvatarUrl('playlist:37i9dQZF1DXcBWIGoYBM5M'),
+    'https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M'
+  )
 })

--- a/test/unit/providers/whatsapp.js
+++ b/test/unit/providers/whatsapp.js
@@ -2,35 +2,37 @@
 
 const test = require('ava')
 
-test('whatsapp provider maps input types to expected URLs', t => {
-  const createHtmlProvider = opts => opts
-  const provider = require('../../../src/providers/whatsapp')({
-    createHtmlProvider,
-    getOgImage: () => 'og-image'
-  })
+const { getAvatarUrl } = require('../../../src/providers/whatsapp')
 
-  t.is(provider.url('34660021551'), 'https://api.whatsapp.com/send/?phone=34660021551')
+test('.getAvatarUrl defaults to phone type', t => {
   t.is(
-    provider.url('channel:0029VaARuQ7KwqSXh9fiMc0m'),
+    getAvatarUrl('34660021551'),
+    'https://api.whatsapp.com/send/?phone=34660021551'
+  )
+})
+
+test('.getAvatarUrl with channel type', t => {
+  t.is(
+    getAvatarUrl('channel:0029VaARuQ7KwqSXh9fiMc0m'),
     'https://www.whatsapp.com/channel/0029VaARuQ7KwqSXh9fiMc0m'
   )
+})
+
+test('.getAvatarUrl with chat type', t => {
   t.is(
-    provider.url('chat:GDoR4ELqJtb2bMy1JI2Hfq'),
-    'https://chat.whatsapp.com/GDoR4ELqJtb2bMy1JI2Hfq'
-  )
-  t.is(
-    provider.url('group:GDoR4ELqJtb2bMy1JI2Hfq'),
+    getAvatarUrl('chat:GDoR4ELqJtb2bMy1JI2Hfq'),
     'https://chat.whatsapp.com/GDoR4ELqJtb2bMy1JI2Hfq'
   )
 })
 
-test('whatsapp provider throws for unsupported input type', t => {
-  const createHtmlProvider = opts => opts
-  const provider = require('../../../src/providers/whatsapp')({
-    createHtmlProvider,
-    getOgImage: () => 'og-image'
-  })
+test('.getAvatarUrl with group type', t => {
+  t.is(
+    getAvatarUrl('group:GDoR4ELqJtb2bMy1JI2Hfq'),
+    'https://chat.whatsapp.com/GDoR4ELqJtb2bMy1JI2Hfq'
+  )
+})
 
-  const error = t.throws(() => provider.url('unsupported:value'))
+test('.getAvatarUrl throws for unsupported type', t => {
+  const error = t.throws(() => getAvatarUrl('unsupported:value'))
   t.is(error.message, 'Unsupported WhatsApp type: unsupported')
 })

--- a/test/unit/providers/youtube.js
+++ b/test/unit/providers/youtube.js
@@ -2,14 +2,23 @@
 
 const test = require('ava')
 
-const createHtmlProvider = opts => opts
-const getOgImage = () => 'og-image'
+const { getAvatarUrl } = require('../../../src/providers/youtube')
 
-test('youtube provider supports handles and channel ids', t => {
-  const provider = require('../../../src/providers/youtube')({ createHtmlProvider, getOgImage })
+test('.getAvatarUrl prepends @ for plain username', t => {
+  t.is(getAvatarUrl('natelive7'), 'https://www.youtube.com/@natelive7')
+})
 
-  t.is(provider.url('natelive7'), 'https://www.youtube.com/@natelive7')
-  t.is(provider.url('@natelive7'), 'https://www.youtube.com/@natelive7')
-  t.is(provider.url('UC_x5XG1OV2P6uZZ5FSM9Ttw'), 'https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw')
-  t.is(provider.url('UC1234'), 'https://www.youtube.com/@UC1234')
+test('.getAvatarUrl keeps existing @ prefix', t => {
+  t.is(getAvatarUrl('@natelive7'), 'https://www.youtube.com/@natelive7')
+})
+
+test('.getAvatarUrl uses channel path for 24-char UC ids', t => {
+  t.is(
+    getAvatarUrl('UC_x5XG1OV2P6uZZ5FSM9Ttw'),
+    'https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw'
+  )
+})
+
+test('.getAvatarUrl treats short UC prefix as username', t => {
+  t.is(getAvatarUrl('UC1234'), 'https://www.youtube.com/@UC1234')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk refactor that mainly exposes internal helper functions and adjusts URL-building logic; primary risk is minor behavior drift in provider `url` output or module export shape.
> 
> **Overview**
> Standardizes several providers to expose their URL-building/parsing helpers (e.g., `module.exports.getAvatarUrl`, `module.exports.parseMastodonInput`, `module.exports.OPENSTREETMAP_USER_ID_REGEX`) and wires the providers to use these named helpers internally.
> 
> Adds/updates unit tests to directly cover these helpers and edge cases (LinkedIn/Spotify/YouTube/WhatsApp/Printables URL formation, OnlyFans JSON-LD handling, Mastodon input parsing, and OpenStreetMap numeric-id vs username branching).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327f6dd2957182c9819df24b1c83ebed450e1b8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->