### PR TITLE
fix(steam): private profiles

### DIFF
--- a/src/providers/steam.js
+++ b/src/providers/steam.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const STEAM_DEFAULT_OG_IMAGE = 'steam_share_image.jpg'
+
 const getAvatarUrl = input => {
   const [first, second] = input.split(':')
   const type = second ? first : 'id'
@@ -23,7 +25,12 @@ module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'steam',
     url: getAvatarUrl,
-    getter: getOgImage
+    getter: $ => {
+      const ogImage = getOgImage($)
+      const hasDefaultOgImage = ogImage?.includes(STEAM_DEFAULT_OG_IMAGE)
+      if (ogImage && !hasDefaultOgImage) return ogImage
+      return $('source[srcset]').attr('srcset')
+    }
   })
 
 module.exports.getAvatarUrl = getAvatarUrl

--- a/test/unit/providers/steam.js
+++ b/test/unit/providers/steam.js
@@ -7,6 +7,12 @@ const getOgImage = require('../../../src/util/get-og-image')
 
 const { getAvatarUrl } = require('../../../src/providers/steam')
 
+const createSteam = () =>
+  require('../../../src/providers/steam')({
+    createHtmlProvider: opts => opts,
+    getOgImage
+  })
+
 test('.getAvatarUrl defaults to id path', t => {
   t.is(getAvatarUrl('Kikobeats'), 'https://steamcommunity.com/id/Kikobeats')
 })
@@ -39,13 +45,7 @@ test('.getter extracts og:image from steam html markup', t => {
     </html>
   `
   const $ = cheerio.load(html)
-
-  const createHtmlProvider = opts => opts
-
-  const steam = require('../../../src/providers/steam')({
-    createHtmlProvider,
-    getOgImage
-  })
+  const steam = createSteam()
 
   t.is(
     steam.getter($),
@@ -62,16 +62,35 @@ test('.getter extracts og:image from steam group html markup', t => {
     </html>
   `
   const $ = cheerio.load(html)
-
-  const createHtmlProvider = opts => opts
-
-  const steam = require('../../../src/providers/steam')({
-    createHtmlProvider,
-    getOgImage
-  })
+  const steam = createSteam()
 
   t.is(
     steam.getter($),
     'https://avatars.fastly.steamstatic.com/34c730c9c7dac891ffa089ab7e0b7ed333235700_full.jpg'
+  )
+})
+
+test('.getter falls back to profile avatar when og:image is steam default image', t => {
+  const html = `
+    <html>
+      <head>
+        <meta property="og:image" content="https://community.fastly.steamstatic.com/public/shared/images/responsive/steam_share_image.jpg" />
+      </head>
+      <body>
+        <div class="playerAvatar profile_header_size offline">
+          <picture>
+            <source srcset="https://avatars.fastly.steamstatic.com/c5d56249ee5d28a07db4ac9f7f60af961fab5426_full.jpg" />
+            <img srcset="https://avatars.fastly.steamstatic.com/c5d56249ee5d28a07db4ac9f7f60af961fab5426_full.jpg" />
+          </picture>
+        </div>
+      </body>
+    </html>
+  `
+  const $ = cheerio.load(html)
+  const steam = createSteam()
+
+  t.is(
+    steam.getter($),
+    'https://avatars.fastly.steamstatic.com/c5d56249ee5d28a07db4ac9f7f60af961fab5426_full.jpg'
   )
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: localized change to Steam provider image extraction logic with added unit coverage; only affects how avatar URLs are derived when `og:image` is the Steam default placeholder.
> 
> **Overview**
> Improves the Steam provider `getter` to avoid returning Steam’s default `og:image` placeholder (`steam_share_image.jpg`). When the placeholder is detected (or `og:image` is missing), it now falls back to extracting the profile avatar from the page’s `source[srcset]`.
> 
> Updates unit tests to reuse a `createSteam` helper and adds coverage for the new fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441ba305494da8cade710ca633d4b35f0d9bfa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->