### PR TITLE
feat: add xboxgamertag support

### DIFF
--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -36,6 +36,7 @@ const providersBy = {
     'twitch',
     'vimeo',
     'x',
+    'xboxgamertag',
     'youtube'
   ],
   domain: ['microlink']
@@ -81,6 +82,7 @@ module.exports = ctx => {
     vimeo: require('./vimeo')(ctx),
     whatsapp: require('./whatsapp')(ctx),
     x: require('./x')(ctx),
+    xboxgamertag: require('./xboxgamertag')(ctx),
     youtube: require('./youtube')(ctx)
   }
 

--- a/src/providers/xboxgamertag.js
+++ b/src/providers/xboxgamertag.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const getAvatarUrl = input =>
+  `https://xboxgamertag.com/search/${encodeURIComponent(input)}`
+
+const ensureProtocol = url =>
+  typeof url === 'string' && url.startsWith('//') ? `https:${url}` : url
+
+module.exports = ({ createHtmlProvider }) =>
+  createHtmlProvider({
+    name: 'xboxgamertag',
+    url: getAvatarUrl,
+    getter: $ => ensureProtocol($('.page-header .avatar img').attr('src'))
+  })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/test/unit/providers/xboxgamertag.js
+++ b/test/unit/providers/xboxgamertag.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const cheerio = require('cheerio')
+const test = require('ava')
+
+const { getAvatarUrl } = require('../../../src/providers/xboxgamertag')
+
+test('.getAvatarUrl builds search URL', t => {
+  t.is(getAvatarUrl('P3'), 'https://xboxgamertag.com/search/P3')
+})
+
+test('.getAvatarUrl encodes special characters', t => {
+  t.is(
+    getAvatarUrl('Major Nelson'),
+    'https://xboxgamertag.com/search/Major%20Nelson'
+  )
+})
+
+const createHtmlProvider = opts => opts
+
+const xboxgamertag = require('../../../src/providers/xboxgamertag')({
+  createHtmlProvider
+})
+
+test('getter extracts the profile avatar from xboxgamertag markup', t => {
+  const $ = cheerio.load(`
+    <div class="page-header">
+      <div class="row">
+        <div class="col-auto avatar">
+          <a href="/search/P3">
+            <img
+              class="rounded img-thumbnail"
+              src="//images.weserv.nl/?url=https://images-eds-ssl.xboxlive.com/image?url=example&amp;format=png&amp;maxage=1d&amp;output=webp&amp;w=90&amp;h=90"
+            >
+          </a>
+        </div>
+      </div>
+    </div>
+  `)
+
+  t.is(
+    xboxgamertag.getter($),
+    'https://images.weserv.nl/?url=https://images-eds-ssl.xboxlive.com/image?url=example&format=png&maxage=1d&output=webp&w=90&h=90'
+  )
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone provider and tests with minimal impact beyond the provider registry; main risk is reliance on third-party page markup that could change.
> 
> **Overview**
> Adds support for the `xboxgamertag` provider by registering it in `src/providers/index.js` for `username` lookups.
> 
> Introduces `src/providers/xboxgamertag.js`, which builds a `https://xboxgamertag.com/search/<gamertag>` URL and scrapes the avatar image `src` (normalizing protocol-relative URLs). Includes new unit tests covering URL construction, encoding, and avatar extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2969fc1e6fccf4684dbdc499372b5d6009fe714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->