### PR TITLE
fix(psnprofiles): handle 404

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ module.exports = ({ constants: userConstants, redis, onFetchHTML } = {}) => {
   })
   const createBrowser = require('./util/browserless')(constants)
   const getHTML = require('./util/html-get')({ createBrowser, got })
-  const { createHtmlProvider, getOgImage } = require('./util/html-provider')({
+  const { createHtmlProvider, getOgImage, NOT_FOUND } = require('./util/html-provider')({
     ...constants,
     getHTML,
     onFetchHTML
@@ -39,6 +39,7 @@ module.exports = ({ constants: userConstants, redis, onFetchHTML } = {}) => {
     constants,
     createHtmlProvider,
     getOgImage,
+    NOT_FOUND,
     got,
     isReservedIp,
     itunesSearchCache: cache.itunesSearchCache

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,12 @@ module.exports = ({ constants: userConstants, redis, onFetchHTML } = {}) => {
   })
   const createBrowser = require('./util/browserless')(constants)
   const getHTML = require('./util/html-get')({ createBrowser, got })
-  const { createHtmlProvider, getOgImage, NOT_FOUND } = require('./util/html-provider')({
-    ...constants,
-    getHTML,
-    onFetchHTML
-  })
+  const { createHtmlProvider, getOgImage, NOT_FOUND } =
+    require('./util/html-provider')({
+      ...constants,
+      getHTML,
+      onFetchHTML
+    })
 
   const providerCtx = {
     constants,

--- a/src/providers/psnprofiles.js
+++ b/src/providers/psnprofiles.js
@@ -9,7 +9,7 @@ module.exports = ({ createHtmlProvider, getOgImage, NOT_FOUND }) =>
   createHtmlProvider({
     name: 'psnprofiles',
     url: input => `https://psnprofiles.com/${input}`,
-    getter: ({ $ }) => getAvatarUrl({ $, getOgImage, NOT_FOUND })
+    getter: $ => getAvatarUrl({ $, getOgImage, NOT_FOUND })
   })
 
 module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/psnprofiles.js
+++ b/src/providers/psnprofiles.js
@@ -1,8 +1,15 @@
 'use strict'
 
-module.exports = ({ createHtmlProvider, getOgImage }) =>
+const getAvatarUrl = ({ $, getOgImage, NOT_FOUND }) => {
+  const ogImage = getOgImage($)
+  return ogImage === undefined ? NOT_FOUND : ogImage
+}
+
+module.exports = ({ createHtmlProvider, getOgImage, NOT_FOUND }) =>
   createHtmlProvider({
     name: 'psnprofiles',
     url: input => `https://psnprofiles.com/${input}`,
-    getter: getOgImage
+    getter: ({ $ }) => getAvatarUrl({ $, getOgImage, NOT_FOUND })
   })
+
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -33,16 +33,37 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
    * @param {object} opts
    * @param {string} opts.name - Provider identifier used in logs and metrics.
    * @param {(input: string) => string | Promise<string>} opts.url - Builds the URL to fetch for a given input.
-   * @param {($: cheerio.CheerioAPI) => string | undefined} opts.getter
+   * @param {(context: {
+   *   $: cheerio.CheerioAPI,
+   *   statusCode: number,
+   *   url: string | undefined,
+   *   redirects: Array<{ statusCode: number, url: string }>
+   * }) => string | symbol | undefined} opts.getter
    *   Extracts the avatar URL from the fetched HTML.
-   *   - `string`    — avatar URL found (success).
+   *   - `string`     — avatar URL found (success).
+   *   - `NOT_FOUND`  — provider-level miss.
    *   - `undefined`  — avatar not found (normal failure, no retry).
+   * @param {(context: {
+   *   $: cheerio.CheerioAPI,
+   *   statusCode: number,
+   *   url: string | undefined,
+   *   redirects: Array<{ statusCode: number, url: string }>
+   * }) => boolean} [opts.isNotFound]
+   *   Optional provider-specific not-found detector for pages that return 200
+   *   after redirecting to a generic search/results page.
    * @param {(context: { $: cheerio.CheerioAPI, statusCode: number }) => boolean} [opts.isBlocked]
    *   Optional provider-specific blocked-page detector, checked after the
    *   default `is-antibot` check when getter returns empty/undefined.
    * @param {() => object} [opts.htmlOpts] - Returns extra options merged into the fetch call.
    */
-  const createHtmlProvider = ({ name, url, getter, isBlocked, htmlOpts }) => {
+  const createHtmlProvider = ({
+    name,
+    url,
+    getter,
+    isNotFound,
+    isBlocked,
+    htmlOpts
+  }) => {
     const provider = async function (input, context) {
       const providerUrl = await url(input)
 
@@ -63,7 +84,9 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
 
         const {
           $,
+          url: responseUrl,
           statusCode,
+          redirects = [],
           headers: responseHeaders = {}
         } = await getHTML(providerUrl, fetchOpts)
 
@@ -73,6 +96,8 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             : undefined
         attempt.lastHeaders = responseHeaders
         attempt.lastStatusCode = statusCode
+        attempt.lastUrl = responseUrl
+        attempt.lastRedirects = redirects
 
         if (isStatusCodeMissing(statusCode)) {
           const code = EMPTY_PROVIDER_VALUE_CODE.MISSING_STATUS_CODE
@@ -89,12 +114,23 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           })
         }
 
-        if (statusCode === httpStatus.NOT_FOUND) {
-          log.error({ statusCode, status: 'not_found' })
+        const extractionContext = {
+          $,
+          statusCode,
+          url: responseUrl,
+          redirects
+        }
+        const result = getter(extractionContext)
+        const notFound =
+          statusCode === httpStatus.NOT_FOUND ||
+          result === NOT_FOUND ||
+          isNotFound?.(extractionContext)
+
+        if (notFound) {
+          log.error({ statusCode, status: 'not_found', url: responseUrl })
           return NOT_FOUND
         }
 
-        const result = getter($)
         if (typeof result !== 'string' || result === '') {
           const error = createProviderError({
             provider: name,

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -33,37 +33,17 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
    * @param {object} opts
    * @param {string} opts.name - Provider identifier used in logs and metrics.
    * @param {(input: string) => string | Promise<string>} opts.url - Builds the URL to fetch for a given input.
-   * @param {(context: {
-   *   $: cheerio.CheerioAPI,
-   *   statusCode: number,
-   *   url: string | undefined,
-   *   redirects: Array<{ statusCode: number, url: string }>
-   * }) => string | symbol | undefined} opts.getter
+   * @param {($: cheerio.CheerioAPI) => string | symbol | undefined} opts.getter
    *   Extracts the avatar URL from the fetched HTML.
    *   - `string`     — avatar URL found (success).
    *   - `NOT_FOUND`  — provider-level miss.
    *   - `undefined`  — avatar not found (normal failure, no retry).
-   * @param {(context: {
-   *   $: cheerio.CheerioAPI,
-   *   statusCode: number,
-   *   url: string | undefined,
-   *   redirects: Array<{ statusCode: number, url: string }>
-   * }) => boolean} [opts.isNotFound]
-   *   Optional provider-specific not-found detector for pages that return 200
-   *   after redirecting to a generic search/results page.
    * @param {(context: { $: cheerio.CheerioAPI, statusCode: number }) => boolean} [opts.isBlocked]
    *   Optional provider-specific blocked-page detector, checked after the
    *   default `is-antibot` check when getter returns empty/undefined.
    * @param {() => object} [opts.htmlOpts] - Returns extra options merged into the fetch call.
    */
-  const createHtmlProvider = ({
-    name,
-    url,
-    getter,
-    isNotFound,
-    isBlocked,
-    htmlOpts
-  }) => {
+  const createHtmlProvider = ({ name, url, getter, isBlocked, htmlOpts }) => {
     const provider = async function (input, context) {
       const providerUrl = await url(input)
 
@@ -82,13 +62,10 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
 
         const log = debug.duration({ provider: name, input, providerUrl, tier })
 
-        const {
-          $,
-          url: responseUrl,
-          statusCode,
-          redirects = [],
-          headers: responseHeaders = {}
-        } = await getHTML(providerUrl, fetchOpts)
+        const { $, statusCode, headers: responseHeaders = {} } = await getHTML(
+          providerUrl,
+          fetchOpts
+        )
 
         attempt.lastHtml =
           typeof $ === 'function' && typeof $.html === 'function'
@@ -96,8 +73,6 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             : undefined
         attempt.lastHeaders = responseHeaders
         attempt.lastStatusCode = statusCode
-        attempt.lastUrl = responseUrl
-        attempt.lastRedirects = redirects
 
         if (isStatusCodeMissing(statusCode)) {
           const code = EMPTY_PROVIDER_VALUE_CODE.MISSING_STATUS_CODE
@@ -114,20 +89,9 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           })
         }
 
-        const extractionContext = {
-          $,
-          statusCode,
-          url: responseUrl,
-          redirects
-        }
-        const result = getter(extractionContext)
-        const notFound =
-          statusCode === httpStatus.NOT_FOUND ||
-          result === NOT_FOUND ||
-          isNotFound?.(extractionContext)
-
-        if (notFound) {
-          log.error({ statusCode, status: 'not_found', url: responseUrl })
+        const result = getter($)
+        if (statusCode === httpStatus.NOT_FOUND || result === NOT_FOUND) {
+          log.error({ statusCode, status: 'not_found' })
           return NOT_FOUND
         }
 

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -38,12 +38,9 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
    *   - `string`     — avatar URL found (success).
    *   - `NOT_FOUND`  — provider-level miss.
    *   - `undefined`  — avatar not found (normal failure, no retry).
-   * @param {(context: { $: cheerio.CheerioAPI, statusCode: number }) => boolean} [opts.isBlocked]
-   *   Optional provider-specific blocked-page detector, checked after the
-   *   default `is-antibot` check when getter returns empty/undefined.
    * @param {() => object} [opts.htmlOpts] - Returns extra options merged into the fetch call.
    */
-  const createHtmlProvider = ({ name, url, getter, isBlocked, htmlOpts }) => {
+  const createHtmlProvider = ({ name, url, getter, htmlOpts }) => {
     const provider = async function (input, context) {
       const providerUrl = await url(input)
 
@@ -90,13 +87,13 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
         }
 
         const result = getter($)
-        if (statusCode === httpStatus.NOT_FOUND || result === NOT_FOUND) {
+        if (statusCode === httpStatus.NOT_FOUND) {
           log.error({ statusCode, status: 'not_found' })
           return NOT_FOUND
         }
 
-        if (typeof result !== 'string' || result === '') {
-          const error = createProviderError({
+        const createEmptyGetterResultError = () =>
+          createProviderError({
             provider: name,
             statusCode,
             code: EMPTY_PROVIDER_VALUE_CODE.EMPTY_GETTER_RESULT,
@@ -107,11 +104,11 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             }
           })
 
+        const getBlockedStatus = () => {
           const isRateLimited = statusCode === httpStatus.TOO_MANY_REQUESTS
-          const providerBlocked = isBlocked?.({ $, statusCode })
 
           const { detected: antibotDetected, provider: antibotProvider } =
-            isRateLimited || providerBlocked
+            isRateLimited
               ? { detected: false, provider: null }
               : isAntibot({
                 url: providerUrl,
@@ -120,13 +117,43 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
                 body: attempt.lastHtml
               })
 
-          if (isRateLimited || providerBlocked || antibotDetected) {
-            error.blocked = true
+          return {
+            isBlocked: isRateLimited || antibotDetected,
+            antibotProvider
           }
+        }
+
+        const isEmptyGetterResult = typeof result !== 'string' || result === ''
+
+        // Some providers encode not-found via getter output. Check antibot
+        // first so challenge pages are retried as blocked, not treated as 404.
+        if (result === NOT_FOUND || isEmptyGetterResult) {
+          const { isBlocked: shouldMarkBlocked, antibotProvider } =
+            getBlockedStatus()
+
+          if (shouldMarkBlocked) {
+            const error = createEmptyGetterResultError()
+            error.blocked = true
+
+            log.error({
+              statusCode,
+              status: 'blocked',
+              antibot: antibotProvider ?? undefined,
+              userAgent: fetchOpts.headers['user-agent']
+            })
+
+            throw error
+          }
+
+          if (result === NOT_FOUND) {
+            log.error({ statusCode, status: 'not_found' })
+            return NOT_FOUND
+          }
+
+          const error = createEmptyGetterResultError()
 
           log.error({
             statusCode,
-            status: error.blocked ? 'blocked' : undefined,
             antibot: antibotProvider ?? undefined,
             userAgent: fetchOpts.headers['user-agent']
           })

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -28,6 +28,12 @@ const createProviderError = ({ provider, statusCode, cause, code }) =>
     message: 'Empty value returned by the provider.'
   })
 
+const createErrorCause = ({ html, headers, statusCode }) => ({
+  html,
+  headers,
+  statusCode
+})
+
 module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
   /**
    * @param {object} opts
@@ -41,7 +47,7 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
    * @param {() => object} [opts.htmlOpts] - Returns extra options merged into the fetch call.
    */
   const createHtmlProvider = ({ name, url, getter, htmlOpts }) => {
-    const provider = async function (input, context) {
+    async function provider (input, context) {
       const providerUrl = await url(input)
 
       const attempt = async gotOpts => {
@@ -54,15 +60,17 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           },
           timeout: PROXY_TIMEOUT
         }
-        const fetchOpts = gotOpts ? { ...defaultOpts, ...gotOpts } : defaultOpts
+        const fetchOpts = { ...defaultOpts, ...gotOpts }
+        const userAgent = fetchOpts.headers['user-agent']
         const tier = fetchOpts.tier ?? 'origin'
 
         const log = debug.duration({ provider: name, input, providerUrl, tier })
 
-        const { $, statusCode, headers: responseHeaders = {} } = await getHTML(
-          providerUrl,
-          fetchOpts
-        )
+        const {
+          $,
+          statusCode,
+          headers: responseHeaders = {}
+        } = await getHTML(providerUrl, fetchOpts)
 
         attempt.lastHtml =
           typeof $ === 'function' && typeof $.html === 'function'
@@ -70,6 +78,11 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             : undefined
         attempt.lastHeaders = responseHeaders
         attempt.lastStatusCode = statusCode
+        const errorCause = createErrorCause({
+          html: attempt.lastHtml,
+          headers: responseHeaders,
+          statusCode
+        })
 
         if (isStatusCodeMissing(statusCode)) {
           const code = EMPTY_PROVIDER_VALUE_CODE.MISSING_STATUS_CODE
@@ -77,11 +90,7 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           throw createProviderError({
             provider: name,
             statusCode,
-            cause: {
-              html: attempt.lastHtml,
-              headers: responseHeaders,
-              statusCode
-            },
+            cause: errorCause,
             code
           })
         }
@@ -92,33 +101,29 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           return NOT_FOUND
         }
 
-        const createEmptyGetterResultError = () =>
-          createProviderError({
+        function createEmptyGetterResultError () {
+          return createProviderError({
             provider: name,
             statusCode,
             code: EMPTY_PROVIDER_VALUE_CODE.EMPTY_GETTER_RESULT,
-            cause: {
-              html: attempt.lastHtml,
-              headers: responseHeaders,
-              statusCode
-            }
+            cause: errorCause
           })
+        }
 
-        const getBlockedStatus = () => {
+        function getBlockedStatus () {
           const isRateLimited = statusCode === httpStatus.TOO_MANY_REQUESTS
+          if (isRateLimited) return { isBlocked: true, antibotProvider: null }
 
           const { detected: antibotDetected, provider: antibotProvider } =
-            isRateLimited
-              ? { detected: false, provider: null }
-              : isAntibot({
-                url: providerUrl,
-                statusCode,
-                headers: responseHeaders,
-                body: attempt.lastHtml
-              })
+            isAntibot({
+              url: providerUrl,
+              statusCode,
+              headers: responseHeaders,
+              body: attempt.lastHtml
+            })
 
           return {
-            isBlocked: isRateLimited || antibotDetected,
+            isBlocked: antibotDetected,
             antibotProvider
           }
         }
@@ -146,7 +151,7 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
             statusCode,
             status: 'blocked',
             antibot: antibotProvider ?? undefined,
-            userAgent: fetchOpts.headers['user-agent']
+            userAgent
           })
 
           throw error
@@ -162,7 +167,7 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
         log.error({
           statusCode,
           antibot: antibotProvider ?? undefined,
-          userAgent: fetchOpts.headers['user-agent']
+          userAgent
         })
 
         throw error
@@ -173,8 +178,7 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
       }
 
       const result = await attempt()
-      if (result === NOT_FOUND) return
-      return result
+      return result === NOT_FOUND ? undefined : result
     }
 
     provider.getUrl = url

--- a/src/util/html-provider.js
+++ b/src/util/html-provider.js
@@ -123,37 +123,28 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           }
         }
 
-        const isEmptyGetterResult = typeof result !== 'string' || result === ''
+        if (typeof result === 'string' && result !== '') {
+          const normalizedResult = normalizeUrl(providerUrl, result)
+          log({
+            statusCode,
+            status: 'success',
+            result: normalizedResult
+          })
+          return normalizedResult
+        }
 
         // Some providers encode not-found via getter output. Check antibot
         // first so challenge pages are retried as blocked, not treated as 404.
-        if (result === NOT_FOUND || isEmptyGetterResult) {
-          const { isBlocked: shouldMarkBlocked, antibotProvider } =
-            getBlockedStatus()
+        const { isBlocked: shouldMarkBlocked, antibotProvider } =
+          getBlockedStatus()
 
-          if (shouldMarkBlocked) {
-            const error = createEmptyGetterResultError()
-            error.blocked = true
-
-            log.error({
-              statusCode,
-              status: 'blocked',
-              antibot: antibotProvider ?? undefined,
-              userAgent: fetchOpts.headers['user-agent']
-            })
-
-            throw error
-          }
-
-          if (result === NOT_FOUND) {
-            log.error({ statusCode, status: 'not_found' })
-            return NOT_FOUND
-          }
-
+        if (shouldMarkBlocked) {
           const error = createEmptyGetterResultError()
+          error.blocked = true
 
           log.error({
             statusCode,
+            status: 'blocked',
             antibot: antibotProvider ?? undefined,
             userAgent: fetchOpts.headers['user-agent']
           })
@@ -161,13 +152,20 @@ module.exports = ({ PROXY_TIMEOUT, getHTML, onFetchHTML }) => {
           throw error
         }
 
-        const normalizedResult = normalizeUrl(providerUrl, result)
-        log({
+        if (result === NOT_FOUND) {
+          log.error({ statusCode, status: 'not_found' })
+          return NOT_FOUND
+        }
+
+        const error = createEmptyGetterResultError()
+
+        log.error({
           statusCode,
-          status: 'success',
-          result: normalizedResult
+          antibot: antibotProvider ?? undefined,
+          userAgent: fetchOpts.headers['user-agent']
         })
-        return normalizedResult
+
+        throw error
       }
 
       if (typeof onFetchHTML === 'function') {

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -267,10 +267,7 @@ test('psnprofiles getter returns og:image URL for valid profile page', t => {
       `<meta property="og:image" content="${avatarUrl}" />` +
       '</html>'
   )
-  t.is(
-    psnprofiles.getter({ $, statusCode: 200, url: undefined, redirects: [] }),
-    avatarUrl
-  )
+  t.is(psnprofiles.getter($), avatarUrl)
 })
 
 test('tumblr getter returns og:image URL for valid profile page', t => {

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -257,7 +257,8 @@ test('facebook getter returns og:image URL from facebook profile markup', t => {
 test('psnprofiles getter returns og:image URL for valid profile page', t => {
   const psnprofiles = require('../../../src/providers/psnprofiles')({
     createHtmlProvider,
-    getOgImage
+    getOgImage,
+    NOT_FOUND: Symbol('NOT_FOUND')
   })
 
   const avatarUrl = 'https://i.psnprofiles.com/avatars/l/G12345abcdef.png'
@@ -266,7 +267,10 @@ test('psnprofiles getter returns og:image URL for valid profile page', t => {
       `<meta property="og:image" content="${avatarUrl}" />` +
       '</html>'
   )
-  t.is(psnprofiles.getter($), avatarUrl)
+  t.is(
+    psnprofiles.getter({ $, statusCode: 200, url: undefined, redirects: [] }),
+    avatarUrl
+  )
 })
 
 test('tumblr getter returns og:image URL for valid profile page', t => {

--- a/test/unit/providers/psnprofiles.js
+++ b/test/unit/providers/psnprofiles.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const test = require('ava')
+const cheerio = require('cheerio')
+
+const { NOT_FOUND } = require('../../../src/util/html-provider')
+const { getAvatarUrl } = require('../../../src/providers/psnprofiles')
+
+test('getAvatarUrl returns NOT_FOUND when og:image is missing', t => {
+  const $ = cheerio.load('<html><title>PSNProfiles</title></html>')
+
+  t.is(
+    getAvatarUrl({
+      $,
+      getOgImage: $ => $('meta[property="og:image"]').attr('content'),
+      NOT_FOUND
+    }),
+    NOT_FOUND
+  )
+})
+
+test('getAvatarUrl returns og:image when present', t => {
+  const $ = cheerio.load(
+    '<meta property="og:image" content="https://i.psnprofiles.com/avatar.png" />'
+  )
+
+  t.is(
+    getAvatarUrl({
+      $,
+      getOgImage: $ => $('meta[property="og:image"]').attr('content'),
+      NOT_FOUND
+    }),
+    'https://i.psnprofiles.com/avatar.png'
+  )
+})

--- a/test/unit/util/html-provider.js
+++ b/test/unit/util/html-provider.js
@@ -19,7 +19,6 @@ const createProvider = (opts = {}) => {
     name: 'test-provider',
     url: () => opts.providerUrl ?? 'https://www.openstreetmap.org/user/Terence',
     getter: opts.getter ?? (() => opts.getterResult),
-    isNotFound: opts.isNotFound,
     isBlocked: opts.isBlocked,
     htmlOpts: opts.htmlOpts
   })
@@ -93,22 +92,6 @@ test('createHtmlProvider returns undefined when status is 404 and no onFetchHTML
     providerUrl: 'https://www.reddit.com/user/kikobeats/',
     getterResult: '/assets/avatar.svg',
     responseStatusCode: 404
-  })
-
-  const result = await runProvider(provider)
-
-  t.is(result, undefined)
-})
-
-test('createHtmlProvider returns undefined when isNotFound matches final response URL', async t => {
-  const provider = createProvider({
-    getHTML: async () => ({
-      $: {},
-      statusCode: 200,
-      url: 'https://example.com/?user=missing'
-    }),
-    getterResult: 'https://cdn.example.com/avatar.png',
-    isNotFound: ({ url }) => url === 'https://example.com/?user=missing'
   })
 
   const result = await runProvider(provider)

--- a/test/unit/util/html-provider.js
+++ b/test/unit/util/html-provider.js
@@ -18,7 +18,8 @@ const createProvider = (opts = {}) => {
   return createHtmlProvider({
     name: 'test-provider',
     url: () => opts.providerUrl ?? 'https://www.openstreetmap.org/user/Terence',
-    getter: () => opts.getterResult,
+    getter: opts.getter ?? (() => opts.getterResult),
+    isNotFound: opts.isNotFound,
     isBlocked: opts.isBlocked,
     htmlOpts: opts.htmlOpts
   })
@@ -92,6 +93,42 @@ test('createHtmlProvider returns undefined when status is 404 and no onFetchHTML
     providerUrl: 'https://www.reddit.com/user/kikobeats/',
     getterResult: '/assets/avatar.svg',
     responseStatusCode: 404
+  })
+
+  const result = await runProvider(provider)
+
+  t.is(result, undefined)
+})
+
+test('createHtmlProvider returns undefined when isNotFound matches final response URL', async t => {
+  const provider = createProvider({
+    getHTML: async () => ({
+      $: {},
+      statusCode: 200,
+      url: 'https://example.com/?user=missing'
+    }),
+    getterResult: 'https://cdn.example.com/avatar.png',
+    isNotFound: ({ url }) => url === 'https://example.com/?user=missing'
+  })
+
+  const result = await runProvider(provider)
+
+  t.is(result, undefined)
+})
+
+test('createHtmlProvider returns avatar URL when getter succeeds', async t => {
+  const provider = createProvider({
+    getter: () => 'https://cdn.example.com/avatar.png'
+  })
+
+  const result = await runProvider(provider)
+
+  t.is(result, 'https://cdn.example.com/avatar.png')
+})
+
+test('createHtmlProvider returns undefined when getter returns NOT_FOUND', async t => {
+  const provider = createProvider({
+    getter: () => NOT_FOUND
   })
 
   const result = await runProvider(provider)

--- a/test/unit/util/html-provider.js
+++ b/test/unit/util/html-provider.js
@@ -19,7 +19,6 @@ const createProvider = (opts = {}) => {
     name: 'test-provider',
     url: () => opts.providerUrl ?? 'https://www.openstreetmap.org/user/Terence',
     getter: opts.getter ?? (() => opts.getterResult),
-    isBlocked: opts.isBlocked,
     htmlOpts: opts.htmlOpts
   })
 }
@@ -117,6 +116,23 @@ test('createHtmlProvider returns undefined when getter returns NOT_FOUND', async
   const result = await runProvider(provider)
 
   t.is(result, undefined)
+})
+
+test('createHtmlProvider prioritizes antibot detection over NOT_FOUND getter output', async t => {
+  const $ = cheerio.load(
+    '<html><head><title>Just a moment...</title></head><body><div class="cf-turnstile"></div></body></html>'
+  )
+
+  const provider = createProvider({
+    getHTML: async () => ({ $, statusCode: 200 }),
+    getter: () => NOT_FOUND
+  })
+
+  const error = await t.throwsAsync(runProvider(provider), {
+    message: 'Empty value returned by the provider.'
+  })
+
+  t.true(error.blocked)
 })
 
 test('attempt returns NOT_FOUND symbol when status is 404 via onFetchHTML', async t => {
@@ -344,31 +360,6 @@ test('createHtmlProvider attaches html to error when getter returns empty', asyn
   t.is(typeof error.cause?.html, 'string')
   t.true(error.cause?.html.includes('<h1>Blocked</h1>'))
   t.deepEqual(error.cause?.headers, responseHeaders)
-  t.is(error.cause?.statusCode, 200)
-})
-
-test('createHtmlProvider sets blocked and attaches html on error when isBlocked returns true', async t => {
-  const $ = cheerio.load('<html><title>Login • Instagram</title></html>')
-
-  const { createHtmlProvider } = require('../../../src/util/html-provider')({
-    PROXY_TIMEOUT: 8000,
-    getHTML: async () => ({ $, statusCode: 200 })
-  })
-
-  const provider = createHtmlProvider({
-    name: 'test-provider',
-    url: () => 'https://www.instagram.com/willsmith',
-    getter: () => undefined,
-    isBlocked: ({ $ }) => $('title').text().includes('Login')
-  })
-
-  const error = await t.throwsAsync(runProvider(provider), {
-    message: 'Empty value returned by the provider.'
-  })
-
-  t.true(error.blocked)
-  t.is(typeof error.cause?.html, 'string')
-  t.true(error.cause?.html.includes('Login'))
   t.is(error.cause?.statusCode, 200)
 })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared `createHtmlProvider` flow used by many providers, changing how empty results, 404s, and antibot/429 cases are classified and logged. Behavior should be covered by updated tests but could affect provider-level miss vs error semantics across integrations.
> 
> **Overview**
> Introduces a shared `NOT_FOUND` sentinel from `util/html-provider` and threads it through provider construction so getters can explicitly signal *provider-level misses* (mapped to `undefined` at the public provider API).
> 
> Refactors `createHtmlProvider` to handle `NOT_FOUND`, 404 responses, and antibot/429 detection more consistently (including prioritizing antibot detection over getter-based not-found), and removes the provider-specific `isBlocked` hook.
> 
> Updates `psnprofiles` to return `NOT_FOUND` when `og:image` is missing, and adds/adjusts unit tests to cover the new sentinel behavior and antibot precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258b5ca2f1f5d31fbb22a02ffb286f52662f09dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->