### PR TITLE
fix(github): use type user

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -9,9 +9,11 @@ const SEARCH_USERS_PER_PAGE = 10
 const SEARCH_COMMITS_PER_PAGE = 20
 const COMMIT_SEARCH_ACCEPT_HEADER = 'application/vnd.github+json'
 
-const normalizeCacheKey = value => value.trim().toLowerCase()
-const createLookupCacheKey = prefix => value =>
-  `${prefix}:${normalizeCacheKey(value)}`
+const normalizeValue = value =>
+  typeof value === 'string' ? value.trim().toLowerCase() : ''
+const getSearchItems = body => body?.items ?? []
+const getUniqueLogins = candidates =>
+  [...new Set(candidates.map(({ login }) => login).filter(Boolean))]
 
 const fetchJsonBody = async ({ got, url, options }) => {
   const { body } = await got(url, {
@@ -22,10 +24,14 @@ const fetchJsonBody = async ({ got, url, options }) => {
   return body
 }
 
-const isResolvablePerson = user =>
-  user?.type === 'User' &&
+const isResolvableAccount = (user, accountType) =>
+  user?.type === accountType &&
   typeof user.login === 'string' &&
   typeof user.avatar_url === 'string'
+
+const isResolvablePerson = user => isResolvableAccount(user, 'User')
+const isResolvableOrganization = user =>
+  isResolvableAccount(user, 'Organization')
 
 const pickLinkedUser = item => {
   if (isResolvablePerson(item.author)) return item.author
@@ -37,21 +43,16 @@ const getUsernameAvatarUrl = ({ constants, input }) =>
     size: constants.AVATAR_SIZE
   })}`
 
-const createSearchUsersByEmail = ({ githubSearchCache, got }) =>
-  memoize(
-    async email => {
-      const body = await fetchJsonBody({
-        got,
-        url: `${GITHUB_API_URL}/search/users?q=${encodeURIComponent(
-          email
-        )}&per_page=${SEARCH_USERS_PER_PAGE}`
-      })
-
-      return body?.items ?? []
-    },
-    githubSearchCache,
-    { key: createLookupCacheKey('search-users') }
-  )
+const createSearchUsersByEmail = ({ got }) =>
+  async email => {
+    const body = await fetchJsonBody({
+      got,
+      url: `${GITHUB_API_URL}/search/users?q=${encodeURIComponent(
+        email
+      )}&per_page=${SEARCH_USERS_PER_PAGE}`
+    })
+    return getSearchItems(body)
+  }
 
 const createGetUser = ({ githubSearchCache, got }) =>
   memoize(
@@ -61,53 +62,72 @@ const createGetUser = ({ githubSearchCache, got }) =>
         url: `${GITHUB_API_URL}/users/${encodeURIComponent(login)}`
       }),
     githubSearchCache,
-    { key: createLookupCacheKey('user') }
+    { key: login => `user:${normalizeValue(login)}` }
   )
 
-const createSearchCommitsByEmail = ({ githubSearchCache, got }) =>
-  memoize(
-    async email => {
-      const body = await fetchJsonBody({
-        got,
-        url: `${GITHUB_API_URL}/search/commits?q=${encodeURIComponent(
-          `author-email:${email}`
-        )}&per_page=${SEARCH_COMMITS_PER_PAGE}`,
-        options: {
-          headers: { accept: COMMIT_SEARCH_ACCEPT_HEADER }
-        }
-      })
+const createSearchCommitsByEmail = ({ got }) =>
+  async email => {
+    const body = await fetchJsonBody({
+      got,
+      url: `${GITHUB_API_URL}/search/commits?q=${encodeURIComponent(
+        `author-email:${email}`
+      )}&per_page=${SEARCH_COMMITS_PER_PAGE}`,
+      options: {
+        headers: { accept: COMMIT_SEARCH_ACCEPT_HEADER }
+      }
+    })
 
-      return body?.items ?? []
-    },
-    githubSearchCache,
-    { key: createLookupCacheKey('search-commits') }
-  )
+    return getSearchItems(body)
+  }
 
-const findExactPublicProfileMatch = async ({
+const findExactPublicProfileMatches = async ({
   email,
   getUser,
   searchUsersByEmail
 }) => {
+  // `searchUsersByEmail` returns lightweight candidate accounts (search items),
+  // so we use each login to fetch full profiles.
   const candidates = await searchUsersByEmail(email)
-  const normalizedEmail = email.toLowerCase()
 
-  for (const candidate of candidates) {
-    const user = await getUser(candidate.login)
+  const candidateLogins = getUniqueLogins(candidates)
 
-    if (
-      isResolvablePerson(user) &&
-      user.email?.toLowerCase() === normalizedEmail
-    ) {
-      return user.avatar_url
+  // Candidate items don't include the public email field, so we hydrate each
+  // login in parallel with /users/:login to validate exact matches.
+  const profiles = await Promise.all(
+    candidateLogins.map(login => getUser(login))
+  )
+
+  let userAvatarUrl
+  let organizationAvatarUrl
+
+  for (const profile of profiles) {
+    if (normalizeValue(profile?.email) !== email) continue
+
+    // Keep first exact match per account type. Caller prioritizes user avatar
+    // and only falls back to organization when no user signal is found.
+    if (!userAvatarUrl && isResolvablePerson(profile)) {
+      userAvatarUrl = profile.avatar_url
     }
+
+    if (!organizationAvatarUrl && isResolvableOrganization(profile)) {
+      organizationAvatarUrl = profile.avatar_url
+    }
+
+    if (userAvatarUrl && organizationAvatarUrl) break
   }
+
+  return { userAvatarUrl, organizationAvatarUrl }
 }
 
 const findCommitConsensusMatch = async ({ email, searchCommitsByEmail }) => {
   const commits = await searchCommitsByEmail(email)
+  if (commits.length === 0) return
+
   const counts = new Map()
 
   for (const item of commits) {
+    // Commit search can reference org/bot identities; pickLinkedUser enforces
+    // that only real user identities are considered in this fallback.
     const linkedUser = pickLinkedUser(item)
     if (!linkedUser) continue
 
@@ -119,41 +139,47 @@ const findCommitConsensusMatch = async ({ email, searchCommitsByEmail }) => {
     entry.count += 1
     counts.set(linkedUser.login, entry)
   }
+  if (counts.size === 0) return
 
   let winner
   for (const entry of counts.values()) {
     if (!winner || entry.count > winner.count) winner = entry
   }
 
+  // Return the dominant user across matched commits.
   return winner?.avatarUrl
 }
 
 module.exports = ({ constants, githubSearchCache, got }) => {
-  const searchUsersByEmail = createSearchUsersByEmail({
-    githubSearchCache,
-    got
-  })
+  const searchUsersByEmail = createSearchUsersByEmail({ got })
   const getUser = createGetUser({ githubSearchCache, got })
-  const searchCommitsByEmail = createSearchCommitsByEmail({
-    githubSearchCache,
-    got
-  })
+  const searchCommitsByEmail = createSearchCommitsByEmail({ got })
 
   return async function github (input) {
     if (!isEmail(input)) return getUsernameAvatarUrl({ constants, input })
+    const email = normalizeValue(input)
 
-    const exactMatch = await findExactPublicProfileMatch({
-      email: input,
-      getUser,
-      searchUsersByEmail
+    // Strategy: exact public user email -> user commit consensus ->
+    // exact organization email.
+    const { userAvatarUrl, organizationAvatarUrl } =
+      await findExactPublicProfileMatches({
+        email,
+        getUser,
+        searchUsersByEmail
+      })
+
+    if (userAvatarUrl) return userAvatarUrl
+
+    const userCommitMatch = await findCommitConsensusMatch({
+      email,
+      searchCommitsByEmail
     })
+    if (userCommitMatch) return userCommitMatch
 
-    if (exactMatch) return exactMatch
-
-    return findCommitConsensusMatch({ email: input, searchCommitsByEmail })
+    return organizationAvatarUrl
   }
 }
 
 module.exports.getUsernameAvatarUrl = getUsernameAvatarUrl
-module.exports.findExactPublicProfileMatch = findExactPublicProfileMatch
+module.exports.findExactPublicProfileMatches = findExactPublicProfileMatches
 module.exports.findCommitConsensusMatch = findCommitConsensusMatch

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -22,6 +22,16 @@ const fetchJsonBody = async ({ got, url, options }) => {
   return body
 }
 
+const isResolvablePerson = user =>
+  user?.type === 'User' &&
+  typeof user.login === 'string' &&
+  typeof user.avatar_url === 'string'
+
+const pickLinkedUser = item => {
+  if (isResolvablePerson(item.author)) return item.author
+  if (isResolvablePerson(item.committer)) return item.committer
+}
+
 const getUsernameAvatarUrl = ({ constants, input }) =>
   `https://github.com/${input}.png?${stringify({
     size: constants.AVATAR_SIZE
@@ -84,7 +94,10 @@ const findExactPublicProfileMatch = async ({
   for (const candidate of candidates) {
     const user = await getUser(candidate.login)
 
-    if (user?.email?.toLowerCase() === normalizedEmail) {
+    if (
+      isResolvablePerson(user) &&
+      user.email?.toLowerCase() === normalizedEmail
+    ) {
       return user.avatar_url
     }
   }
@@ -95,8 +108,8 @@ const findCommitConsensusMatch = async ({ email, searchCommitsByEmail }) => {
   const counts = new Map()
 
   for (const item of commits) {
-    const linkedUser = item.author ?? item.committer
-    if (!linkedUser?.login || !linkedUser?.avatar_url) continue
+    const linkedUser = pickLinkedUser(item)
+    if (!linkedUser) continue
 
     const entry = counts.get(linkedUser.login) ?? {
       avatarUrl: linkedUser.avatar_url,

--- a/test/unit/providers/github.js
+++ b/test/unit/providers/github.js
@@ -31,6 +31,7 @@ test('github resolves exact public profile email match', async t => {
       return {
         body: {
           login: 'Kikobeats',
+          type: 'User',
           email: 'josefrancisco.verdu@gmail.com',
           avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
         }
@@ -62,18 +63,21 @@ test('github falls back to commit search for email input', async t => {
             {
               author: {
                 login: 'Kikobeats',
+                type: 'User',
                 avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
               }
             },
             {
               author: {
                 login: 'Kikobeats',
+                type: 'User',
                 avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
               }
             },
             {
               author: {
                 login: 'someone-else',
+                type: 'User',
                 avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
               }
             }
@@ -126,6 +130,7 @@ test('github memoizes email lookups across repeated calls', async t => {
             {
               author: {
                 login: 'Kikobeats',
+                type: 'User',
                 avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
               }
             }
@@ -143,4 +148,93 @@ test('github memoizes email lookups across repeated calls', async t => {
   t.is(first, 'https://avatars.githubusercontent.com/u/2096101?v=4')
   t.is(second, 'https://avatars.githubusercontent.com/u/2096101?v=4')
   t.is(gotCalls, 2)
+})
+
+test('github commit fallback ignores organizations and keeps user avatar', async t => {
+  const github = createGithub(async (url, opts) => {
+    t.is(opts.responseType, 'json')
+
+    if (url.includes('/search/users?')) {
+      return { body: { items: [] } }
+    }
+
+    if (url.includes('/search/commits?')) {
+      return {
+        body: {
+          items: [
+            {
+              author: {
+                login: 'sindresorhus',
+                type: 'Organization',
+                avatar_url: 'https://avatars.githubusercontent.com/u/13122722?v=4'
+              },
+              committer: {
+                login: 'sindresorhus',
+                type: 'User',
+                avatar_url: 'https://avatars.githubusercontent.com/u/170270?s=400&v=4'
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    throw new Error(`Unexpected URL: ${url}`)
+  })
+
+  const result = await github('sindresorhus@gmail.com')
+
+  t.is(result, 'https://avatars.githubusercontent.com/u/170270?s=400&v=4')
+})
+
+test('github exact email match ignores organizations and falls back to user commit', async t => {
+  const github = createGithub(async (url, opts) => {
+    t.is(opts.responseType, 'json')
+
+    if (url.includes('/search/users?')) {
+      return {
+        body: {
+          items: [{ login: 'sindresorhus' }]
+        }
+      }
+    }
+
+    if (url.endsWith('/users/sindresorhus')) {
+      return {
+        body: {
+          login: 'sindresorhus',
+          type: 'Organization',
+          email: 'sindresorhus@gmail.com',
+          avatar_url: 'https://avatars.githubusercontent.com/u/13122722?v=4'
+        }
+      }
+    }
+
+    if (url.includes('/search/commits?')) {
+      return {
+        body: {
+          items: [
+            {
+              author: {
+                login: 'sindresorhus',
+                type: 'Organization',
+                avatar_url: 'https://avatars.githubusercontent.com/u/13122722?v=4'
+              },
+              committer: {
+                login: 'sindresorhus',
+                type: 'User',
+                avatar_url: 'https://avatars.githubusercontent.com/u/170270?s=400&v=4'
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    throw new Error(`Unexpected URL: ${url}`)
+  })
+
+  const result = await github('sindresorhus@gmail.com')
+
+  t.is(result, 'https://avatars.githubusercontent.com/u/170270?s=400&v=4')
 })

--- a/test/unit/providers/github.js
+++ b/test/unit/providers/github.js
@@ -114,27 +114,24 @@ test('github returns undefined when email cannot be resolved', async t => {
   t.is(result, undefined)
 })
 
-test('github memoizes email lookups across repeated calls', async t => {
-  let gotCalls = 0
-  const github = createGithub(async url => {
-    gotCalls++
+test('github memoizes user profile lookups by login', async t => {
+  let searchUsersCalls = 0
+  let getUserCalls = 0
 
+  const github = createGithub(async url => {
     if (url.includes('/search/users?')) {
-      return { body: { items: [] } }
+      searchUsersCalls++
+      return { body: { items: [{ login: 'Kikobeats' }] } }
     }
 
-    if (url.includes('/search/commits?')) {
+    if (url.endsWith('/users/Kikobeats')) {
+      getUserCalls++
       return {
         body: {
-          items: [
-            {
-              author: {
-                login: 'Kikobeats',
-                type: 'User',
-                avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
-              }
-            }
-          ]
+          login: 'Kikobeats',
+          type: 'User',
+          email: 'josefrancisco.verdu@gmail.com',
+          avatar_url: 'https://avatars.githubusercontent.com/u/2096101?v=4'
         }
       }
     }
@@ -147,7 +144,8 @@ test('github memoizes email lookups across repeated calls', async t => {
 
   t.is(first, 'https://avatars.githubusercontent.com/u/2096101?v=4')
   t.is(second, 'https://avatars.githubusercontent.com/u/2096101?v=4')
-  t.is(gotCalls, 2)
+  t.is(searchUsersCalls, 2)
+  t.is(getUserCalls, 1)
 })
 
 test('github commit fallback ignores organizations and keeps user avatar', async t => {
@@ -237,4 +235,39 @@ test('github exact email match ignores organizations and falls back to user comm
   const result = await github('sindresorhus@gmail.com')
 
   t.is(result, 'https://avatars.githubusercontent.com/u/170270?s=400&v=4')
+})
+
+test('github resolves organization email when user resolution fails', async t => {
+  const github = createGithub(async (url, opts) => {
+    t.is(opts.responseType, 'json')
+
+    if (url.includes('/search/users?')) {
+      return {
+        body: {
+          items: [{ login: 'microlinkhq' }]
+        }
+      }
+    }
+
+    if (url.endsWith('/users/microlinkhq')) {
+      return {
+        body: {
+          login: 'microlinkhq',
+          type: 'Organization',
+          email: 'hello@microlink.io',
+          avatar_url: 'https://avatars.githubusercontent.com/u/13122722?v=4'
+        }
+      }
+    }
+
+    if (url.includes('/search/commits?')) {
+      return { body: { items: [] } }
+    }
+
+    throw new Error(`Unexpected URL: ${url}`)
+  })
+
+  const result = await github('hello@microlink.io')
+
+  t.is(result, 'https://avatars.githubusercontent.com/u/13122722?v=4')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes avatar resolution precedence and filtering (especially around org vs user identities) and alters memoization behavior, which could affect returned avatars and increase GitHub search traffic if not monitored.
> 
> **Overview**
> Updates the GitHub provider’s email-to-avatar resolution to **prefer `User` profiles** and avoid returning organization avatars from commit search results by validating `type`, `login`, and `avatar_url` before considering a candidate.
> 
> Refactors exact-match lookup to hydrate `/search/users` results via parallel `/users/:login` fetches, returning the first exact-match avatar for both user and organization and applying a new strategy order: **exact user email → commit consensus user → exact organization email**. Caching is tightened to memoize only `getUser` lookups (normalized `user:` cache key), and unit tests are expanded/updated to cover the new precedence rules and org-filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddbeed529d7f660eb2375d5bda91389d2ea2706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->