### PR TITLE
feat: add apple store support

### DIFF
--- a/src/providers/apple-music.js
+++ b/src/providers/apple-music.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { $jsonld } = require('@metascraper/helpers')
-const memoize = require('@keyvhq/memoize')
+const { createGetSearchResults } = require('../util/itunes-search')
 
 const APPLE_MUSIC_ID_REGEX = /^\d+$/
 const APPLE_MUSIC_STOREFRONT = 'us'
@@ -36,26 +36,19 @@ const parseInput = input => {
 }
 
 module.exports = ({ createHtmlProvider, itunesSearchCache, got }) => {
-  const searchEntityId = memoize(
-    async ({ query, type }) => {
-      const entityConfig = APPLE_MUSIC_ENTITY_TYPES[type]
-      if (!entityConfig) return
-      const { entity, idKey } = entityConfig
+  const getSearchResults = createGetSearchResults({ got, itunesSearchCache })
 
-      const url = `https://itunes.apple.com/search?term=${encodeURIComponent(
-        query
-      )}&entity=${entity}&limit=1`
-      const body = await got(url, {
-        responseType: 'json',
-        resolveBodyOnly: true
-      })
+  const searchEntityId = async ({ query, type }) => {
+    const entityConfig = APPLE_MUSIC_ENTITY_TYPES[type]
+    if (!entityConfig) return
+    const { entity, idKey } = entityConfig
 
-      const entityId = body?.results?.[0]?.[idKey]
-      return isNumericId(entityId) ? String(entityId) : null
-    },
-    itunesSearchCache,
-    { key: ({ query, type }) => `${type}:${query.trim().toLowerCase()}` }
-  )
+    const [result] = await getSearchResults(
+      `term=${encodeURIComponent(query)}&entity=${entity}&limit=1`
+    )
+    const entityId = result?.[idKey]
+    return isNumericId(entityId) ? String(entityId) : null
+  }
 
   const appleMusicURI = async input => {
     const { hasExplicitType, type, id } = parseInput(input)

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -4,7 +4,6 @@ const { createGetSearchResults } = require('../util/itunes-search')
 
 const ITUNES_LOOKUP_URL = 'https://itunes.apple.com/lookup'
 const COUNTRY_CODE_REGEX = /^[a-z]{2}$/i
-const APP_ID_IN_URL_REGEX = /\/id(\d+)(?:\/|$)/
 
 const getArtworkUrl = result =>
   result?.artworkUrl512 || result?.artworkUrl100 || result?.artworkUrl60
@@ -36,11 +35,6 @@ const parseCountry = value => {
     value: nextValue,
     country: country.toLowerCase()
   }
-}
-
-const getAppIdFromUrl = value => {
-  const parsedUrl = new URL(value)
-  return parsedUrl.pathname.match(APP_ID_IN_URL_REGEX)?.[1]
 }
 
 const getLookupResults = async ({ got, query }) => {
@@ -115,11 +109,6 @@ module.exports = ({ got, itunesSearchCache }) => {
         return getDeveloperAvatar({ got, id: value, country })
       case 'bundle':
         return getBundleAvatar({ got, bundleId: value, country })
-      case 'app-url': {
-        const appId = getAppIdFromUrl(value)
-        if (!appId) throw new Error(`Invalid Apple Store app URL: ${value}`)
-        return getAppAvatar({ got, id: appId, country })
-      }
       case 'app-name':
         return getAppNameAvatar({ got, name: value, country, searchResults })
       case 'dev-name':
@@ -135,4 +124,3 @@ module.exports.getDeveloperAvatar = getDeveloperAvatar
 module.exports.getBundleAvatar = getBundleAvatar
 module.exports.getAppNameAvatar = getAppNameAvatar
 module.exports.getDeveloperNameAvatar = getDeveloperNameAvatar
-module.exports.getAppIdFromUrl = getAppIdFromUrl

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -1,7 +1,8 @@
 'use strict'
 
+const { createGetSearchResults } = require('../util/itunes-search')
+
 const ITUNES_LOOKUP_URL = 'https://itunes.apple.com/lookup'
-const ITUNES_SEARCH_URL = 'https://itunes.apple.com/search'
 const COUNTRY_CODE_REGEX = /^[a-z]{2}$/i
 const APP_ID_IN_URL_REGEX = /\/id(\d+)(?:\/|$)/
 
@@ -50,14 +51,6 @@ const getLookupResults = async ({ got, query }) => {
   return body?.results ?? []
 }
 
-const getSearchResults = async ({ got, query }) => {
-  const body = await got(`${ITUNES_SEARCH_URL}?${query}`, {
-    responseType: 'json',
-    resolveBodyOnly: true
-  })
-  return body?.results ?? []
-}
-
 const getAppAvatar = async ({ got, id, country }) => {
   const query = withCountry({
     query: `id=${encodeURIComponent(id)}&entity=software&limit=1`,
@@ -86,28 +79,32 @@ const getBundleAvatar = async ({ got, bundleId, country }) => {
   return getArtworkUrl(result)
 }
 
-const getAppNameAvatar = async ({ got, name, country }) => {
+const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
+  const getSearchResults = searchResults || createGetSearchResults({ got })
   const query = withCountry({
     query: `term=${encodeURIComponent(name)}&entity=software&limit=1`,
     country
   })
-  const [result] = await getSearchResults({ got, query })
+  const [result] = await getSearchResults(query)
   return getArtworkUrl(result)
 }
 
-const getDeveloperNameAvatar = async ({ got, name, country }) => {
+const getDeveloperNameAvatar = async ({ got, name, country, searchResults }) => {
+  const getSearchResults = searchResults || createGetSearchResults({ got })
   const query = withCountry({
     query: `term=${encodeURIComponent(
       name
     )}&entity=software&attribute=softwareDeveloper&limit=1`,
     country
   })
-  const [result] = await getSearchResults({ got, query })
+  const [result] = await getSearchResults(query)
   return getArtworkUrl(result)
 }
 
-module.exports = ({ got }) =>
-  async function appleStore (input) {
+module.exports = ({ got, itunesSearchCache }) => {
+  const searchResults = createGetSearchResults({ got, itunesSearchCache })
+
+  return async function appleStore (input) {
     const { type, value: rawValue } = parseInput(input)
     const { value, country } = parseCountry(rawValue)
 
@@ -124,13 +121,14 @@ module.exports = ({ got }) =>
         return getAppAvatar({ got, id: appId, country })
       }
       case 'app-name':
-        return getAppNameAvatar({ got, name: value, country })
+        return getAppNameAvatar({ got, name: value, country, searchResults })
       case 'dev-name':
-        return getDeveloperNameAvatar({ got, name: value, country })
+        return getDeveloperNameAvatar({ got, name: value, country, searchResults })
       default:
         throw new Error(`Unsupported Apple Store type: ${type}`)
     }
   }
+}
 
 module.exports.getAppAvatar = getAppAvatar
 module.exports.getDeveloperAvatar = getDeveloperAvatar

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -1,0 +1,140 @@
+'use strict'
+
+const ITUNES_LOOKUP_URL = 'https://itunes.apple.com/lookup'
+const ITUNES_SEARCH_URL = 'https://itunes.apple.com/search'
+const COUNTRY_CODE_REGEX = /^[a-z]{2}$/i
+const APP_ID_IN_URL_REGEX = /\/id(\d+)(?:\/|$)/
+
+const getArtworkUrl = result =>
+  result?.artworkUrl512 || result?.artworkUrl100 || result?.artworkUrl60
+
+const withCountry = ({ query, country }) =>
+  country ? `${query}&country=${encodeURIComponent(country)}` : query
+
+const parseInput = input => {
+  const separatorIndex = input.indexOf(':')
+  if (separatorIndex === -1) return { type: 'app', value: input }
+
+  return {
+    type: input.slice(0, separatorIndex),
+    value: input.slice(separatorIndex + 1)
+  }
+}
+
+const parseCountry = value => {
+  const separatorIndex = value.lastIndexOf('@')
+  if (separatorIndex === -1) return { value, country: undefined }
+
+  const country = value.slice(separatorIndex + 1)
+  if (!COUNTRY_CODE_REGEX.test(country)) return { value, country: undefined }
+
+  const nextValue = value.slice(0, separatorIndex)
+  if (!nextValue) return { value, country: undefined }
+
+  return {
+    value: nextValue,
+    country: country.toLowerCase()
+  }
+}
+
+const getAppIdFromUrl = value => {
+  const parsedUrl = new URL(value)
+  return parsedUrl.pathname.match(APP_ID_IN_URL_REGEX)?.[1]
+}
+
+const getLookupResults = async ({ got, query }) => {
+  const body = await got(`${ITUNES_LOOKUP_URL}?${query}`, {
+    responseType: 'json',
+    resolveBodyOnly: true
+  })
+  return body?.results ?? []
+}
+
+const getSearchResults = async ({ got, query }) => {
+  const body = await got(`${ITUNES_SEARCH_URL}?${query}`, {
+    responseType: 'json',
+    resolveBodyOnly: true
+  })
+  return body?.results ?? []
+}
+
+const getAppAvatar = async ({ got, id, country }) => {
+  const query = withCountry({
+    query: `id=${encodeURIComponent(id)}&entity=software&limit=1`,
+    country
+  })
+  const [result] = await getLookupResults({ got, query })
+  return getArtworkUrl(result)
+}
+
+const getDeveloperAvatar = async ({ got, id, country }) => {
+  const query = withCountry({
+    query: `id=${encodeURIComponent(id)}&entity=software&limit=200`,
+    country
+  })
+  const results = await getLookupResults({ got, query })
+  const softwareResult = results.find(result => result?.kind === 'software')
+  return getArtworkUrl(softwareResult)
+}
+
+const getBundleAvatar = async ({ got, bundleId, country }) => {
+  const query = withCountry({
+    query: `bundleId=${encodeURIComponent(bundleId)}&entity=software&limit=1`,
+    country
+  })
+  const [result] = await getLookupResults({ got, query })
+  return getArtworkUrl(result)
+}
+
+const getAppNameAvatar = async ({ got, name, country }) => {
+  const query = withCountry({
+    query: `term=${encodeURIComponent(name)}&entity=software&limit=1`,
+    country
+  })
+  const [result] = await getSearchResults({ got, query })
+  return getArtworkUrl(result)
+}
+
+const getDeveloperNameAvatar = async ({ got, name, country }) => {
+  const query = withCountry({
+    query: `term=${encodeURIComponent(
+      name
+    )}&entity=software&attribute=softwareDeveloper&limit=1`,
+    country
+  })
+  const [result] = await getSearchResults({ got, query })
+  return getArtworkUrl(result)
+}
+
+module.exports = ({ got }) =>
+  async function appleStore (input) {
+    const { type, value: rawValue } = parseInput(input)
+    const { value, country } = parseCountry(rawValue)
+
+    switch (type) {
+      case 'app':
+        return getAppAvatar({ got, id: value, country })
+      case 'dev':
+        return getDeveloperAvatar({ got, id: value, country })
+      case 'bundle':
+        return getBundleAvatar({ got, bundleId: value, country })
+      case 'app-url': {
+        const appId = getAppIdFromUrl(value)
+        if (!appId) throw new Error(`Invalid Apple Store app URL: ${value}`)
+        return getAppAvatar({ got, id: appId, country })
+      }
+      case 'app-name':
+        return getAppNameAvatar({ got, name: value, country })
+      case 'dev-name':
+        return getDeveloperNameAvatar({ got, name: value, country })
+      default:
+        throw new Error(`Unsupported Apple Store type: ${type}`)
+    }
+  }
+
+module.exports.getAppAvatar = getAppAvatar
+module.exports.getDeveloperAvatar = getDeveloperAvatar
+module.exports.getBundleAvatar = getBundleAvatar
+module.exports.getAppNameAvatar = getAppNameAvatar
+module.exports.getDeveloperNameAvatar = getDeveloperNameAvatar
+module.exports.getAppIdFromUrl = getAppIdFromUrl

--- a/src/providers/flickr.js
+++ b/src/providers/flickr.js
@@ -4,24 +4,33 @@ const BUDDY_ICON_URL_PATTERN = /(?:https?:)?\/\/[^"'()\s]*\/buddyicons\/[^"'()\s
 const CSS_URL_PATTERN = /url\((['"]?)([^)'"]+)\1\)/i
 const unescapePathSlashes = value => value?.replace(/\\\//g, '/')
 
+const parseInput = input => {
+  const [first, second] = input.split(':')
+  return {
+    type: second ? first : 'user',
+    id: second ?? first
+  }
+}
+
 const getBuddyIconFromText = value => {
   const normalizedValue = unescapePathSlashes(value)
   if (typeof normalizedValue !== 'string') return
   return normalizedValue.match(BUDDY_ICON_URL_PATTERN)?.[0]
 }
 
+const getUserProfileUrl = userId => `https://www.flickr.com/photos/${userId}/`
+const getGroupProfileUrl = groupId => `https://www.flickr.com/groups/${groupId}/`
+
 const getAvatarUrl = input => {
-  const [first, second] = input.split(':')
-  const type = second ? first : 'user'
-  const id = second ?? first
+  const { type, id } = parseInput(input)
 
   switch (type) {
     case 'user':
     case 'photos':
-      return `https://www.flickr.com/photos/${id}/`
+      return getUserProfileUrl(id)
     case 'group':
     case 'groups':
-      return `https://www.flickr.com/groups/${id}/`
+      return getGroupProfileUrl(id)
     default:
       throw new Error(`Unsupported Flickr type: ${type}`)
   }

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -4,6 +4,7 @@ const providersBy = {
   email: ['gravatar', 'github'],
   username: [
     'apple-music',
+    'apple-store',
     'behance',
     'bluesky',
     'buymeacoffee',
@@ -49,6 +50,7 @@ const providersBy = {
 module.exports = ctx => {
   const providers = {
     'apple-music': require('./apple-music')(ctx),
+    'apple-store': require('./apple-store')(ctx),
     behance: require('./behance')(ctx),
     bluesky: require('./bluesky')(ctx),
     buymeacoffee: require('./buymeacoffee')(ctx),

--- a/src/util/itunes-search.js
+++ b/src/util/itunes-search.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const memoize = require('@keyvhq/memoize')
+
+const ITUNES_SEARCH_URL = 'https://itunes.apple.com/search'
+
+const getSearchResults = async ({ got, query }) => {
+  const body = await got(`${ITUNES_SEARCH_URL}?${query}`, {
+    responseType: 'json',
+    resolveBodyOnly: true
+  })
+  return body?.results ?? []
+}
+
+const createGetSearchResults = ({ got, itunesSearchCache }) => {
+  const searchResults = query => getSearchResults({ got, query })
+  if (!itunesSearchCache) return searchResults
+
+  return memoize(searchResults, itunesSearchCache, {
+    key: query => query.trim().toLowerCase()
+  })
+}
+
+module.exports = { createGetSearchResults }

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -90,27 +90,6 @@ test('apple-store provider supports bundle id lookups', async t => {
   t.is(avatarUrl, 'https://cdn.apple.com/bundle.jpg')
 })
 
-test('apple-store provider supports app-url input', async t => {
-  const provider = require('../../../src/providers/apple-store')({
-    got: async (url, opts) => {
-      t.is(
-        url,
-        'https://itunes.apple.com/lookup?id=284882215&entity=software&limit=1'
-      )
-      t.is(opts.responseType, 'json')
-      t.true(opts.resolveBodyOnly)
-      return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/from-url.jpg' }]
-      }
-    }
-  })
-
-  const avatarUrl = await provider(
-    'app-url:https://apps.apple.com/us/app/facebook/id284882215'
-  )
-  t.is(avatarUrl, 'https://cdn.apple.com/from-url.jpg')
-})
-
 test('apple-store provider supports app-name search', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async (url, opts) => {
@@ -178,7 +157,7 @@ test('apple-store provider supports dev-name search with country', async t => {
   t.is(avatarUrl, 'https://cdn.apple.com/dev-name.jpg')
 })
 
-test('apple-store provider throws for invalid app-url values', async t => {
+test('apple-store provider throws for unsupported app-url type', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async () => ({ results: [] })
   })
@@ -186,10 +165,7 @@ test('apple-store provider throws for invalid app-url values', async t => {
   const error = await t.throwsAsync(async () =>
     provider('app-url:https://apps.apple.com/us/developer/meta-platforms-inc')
   )
-  t.is(
-    error.message,
-    'Invalid Apple Store app URL: https://apps.apple.com/us/developer/meta-platforms-inc'
-  )
+  t.is(error.message, 'Unsupported Apple Store type: app-url')
 })
 
 test('apple-store provider throws for unsupported type', async t => {

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -1,0 +1,233 @@
+'use strict'
+
+const test = require('ava')
+
+const {
+  getAppAvatar,
+  getDeveloperAvatar,
+  getBundleAvatar,
+  getAppNameAvatar,
+  getDeveloperNameAvatar
+} = require('../../../src/providers/apple-store')
+
+test('apple-store provider defaults to app type', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/lookup?id=284882215&entity=software&limit=1'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-512.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('284882215')
+  t.is(avatarUrl, 'https://cdn.apple.com/app-512.jpg')
+})
+
+test('apple-store provider supports explicit app type with country', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/lookup?id=310633997&entity=software&limit=1&country=es'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-es.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('app:310633997@es')
+  t.is(avatarUrl, 'https://cdn.apple.com/app-es.jpg')
+})
+
+test('apple-store provider supports explicit dev type with country', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/lookup?id=284882218&entity=software&limit=200&country=us'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [
+          { wrapperType: 'artist', artistId: 284882218 },
+          { kind: 'software', artworkUrl512: 'https://cdn.apple.com/dev-app.jpg' }
+        ]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('dev:284882218@US')
+  t.is(avatarUrl, 'https://cdn.apple.com/dev-app.jpg')
+})
+
+test('apple-store provider supports bundle id lookups', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/lookup?bundleId=com.facebook.Facebook&entity=software&limit=1'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/bundle.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('bundle:com.facebook.Facebook')
+  t.is(avatarUrl, 'https://cdn.apple.com/bundle.jpg')
+})
+
+test('apple-store provider supports app-url input', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/lookup?id=284882215&entity=software&limit=1'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/from-url.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider(
+    'app-url:https://apps.apple.com/us/app/facebook/id284882215'
+  )
+  t.is(avatarUrl, 'https://cdn.apple.com/from-url.jpg')
+})
+
+test('apple-store provider supports app-name search', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/search?term=whatsapp&entity=software&limit=1'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-name.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('app-name:whatsapp')
+  t.is(avatarUrl, 'https://cdn.apple.com/app-name.jpg')
+})
+
+test('apple-store provider supports dev-name search with country', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      t.is(
+        url,
+        'https://itunes.apple.com/search?term=meta%20platforms&entity=software&attribute=softwareDeveloper&limit=1&country=gb'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/dev-name.jpg' }]
+      }
+    }
+  })
+
+  const avatarUrl = await provider('dev-name:meta platforms@gb')
+  t.is(avatarUrl, 'https://cdn.apple.com/dev-name.jpg')
+})
+
+test('apple-store provider throws for invalid app-url values', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [] })
+  })
+
+  const error = await t.throwsAsync(async () =>
+    provider('app-url:https://apps.apple.com/us/developer/meta-platforms-inc')
+  )
+  t.is(
+    error.message,
+    'Invalid Apple Store app URL: https://apps.apple.com/us/developer/meta-platforms-inc'
+  )
+})
+
+test('apple-store provider throws for unsupported type', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [] })
+  })
+
+  const error = await t.throwsAsync(async () => provider('genre:action'))
+  t.is(error.message, 'Unsupported Apple Store type: genre')
+})
+
+test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', async t => {
+  const avatarUrl = await getAppAvatar({
+    got: async () => ({
+      results: [{ kind: 'software', artworkUrl100: 'https://cdn.apple.com/app-100.jpg' }]
+    }),
+    id: '389801252'
+  })
+
+  t.is(avatarUrl, 'https://cdn.apple.com/app-100.jpg')
+})
+
+test('getDeveloperAvatar falls back to artworkUrl60 when artworkUrl512 is missing', async t => {
+  const avatarUrl = await getDeveloperAvatar({
+    got: async () => ({
+      results: [{ kind: 'software', artworkUrl60: 'https://cdn.apple.com/dev-60.jpg' }]
+    }),
+    id: '310634000'
+  })
+
+  t.is(avatarUrl, 'https://cdn.apple.com/dev-60.jpg')
+})
+
+test('getBundleAvatar returns undefined when lookup is empty', async t => {
+  const avatarUrl = await getBundleAvatar({
+    got: async () => ({ results: [] }),
+    bundleId: 'com.example.missing'
+  })
+
+  t.is(avatarUrl, undefined)
+})
+
+test('getAppNameAvatar returns undefined when search is empty', async t => {
+  const avatarUrl = await getAppNameAvatar({
+    got: async () => ({ results: [] }),
+    name: 'missing-app'
+  })
+
+  t.is(avatarUrl, undefined)
+})
+
+test('getDeveloperNameAvatar returns undefined when search is empty', async t => {
+  const avatarUrl = await getDeveloperNameAvatar({
+    got: async () => ({ results: [] }),
+    name: 'missing-dev'
+  })
+
+  t.is(avatarUrl, undefined)
+})
+
+test('apple-store provider returns undefined when lookup has no software results', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [{ wrapperType: 'artist', artistId: 1 }] })
+  })
+
+  const appAvatar = await provider('app:999')
+  const devAvatar = await provider('dev:999')
+
+  t.is(appAvatar, undefined)
+  t.is(devAvatar, undefined)
+})

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('ava')
+const Keyv = require('@keyvhq/core')
 
 const {
   getAppAvatar,
@@ -127,6 +128,35 @@ test('apple-store provider supports app-name search', async t => {
 
   const avatarUrl = await provider('app-name:whatsapp')
   t.is(avatarUrl, 'https://cdn.apple.com/app-name.jpg')
+})
+
+test('apple-store provider memoizes app-name iTunes search lookups', async t => {
+  let gotCalls = 0
+  const provider = require('../../../src/providers/apple-store')({
+    got: async (url, opts) => {
+      gotCalls++
+      t.is(
+        url,
+        'https://itunes.apple.com/search?term=whatsapp&entity=software&limit=1'
+      )
+      t.is(opts.responseType, 'json')
+      t.true(opts.resolveBodyOnly)
+      return {
+        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-name.jpg' }]
+      }
+    },
+    itunesSearchCache: new Keyv({
+      namespace: 'itunes-search-test',
+      store: new Map()
+    })
+  })
+
+  const first = await provider('app-name:whatsapp')
+  const second = await provider('app-name:whatsapp')
+
+  t.is(first, 'https://cdn.apple.com/app-name.jpg')
+  t.is(second, 'https://cdn.apple.com/app-name.jpg')
+  t.is(gotCalls, 1)
 })
 
 test('apple-store provider supports dev-name search with country', async t => {

--- a/test/unit/providers/flickr.js
+++ b/test/unit/providers/flickr.js
@@ -3,16 +3,29 @@
 const cheerio = require('cheerio')
 const test = require('ava')
 
-const { getAvatarUrl, getAvatarFromMarkup } = require('../../../src/providers/flickr')
+const {
+  getAvatarUrl,
+  getAvatarFromMarkup
+} = require('../../../src/providers/flickr')
 
-test('.getAvatarUrl defaults to user photostream path', t => {
-  t.is(getAvatarUrl('stevebooth'), 'https://www.flickr.com/photos/stevebooth/')
+test('.getAvatarUrl supports default username input', t => {
+  t.is(
+    getAvatarUrl('nasahqphoto'),
+    'https://www.flickr.com/photos/nasahqphoto/'
+  )
 })
 
-test('.getAvatarUrl supports user NSID', t => {
+test('.getAvatarUrl supports explicit user username input', t => {
   t.is(
-    getAvatarUrl('user:94867603@N03'),
-    'https://www.flickr.com/photos/94867603@N03/'
+    getAvatarUrl('user:nasahqphoto'),
+    'https://www.flickr.com/photos/nasahqphoto/'
+  )
+})
+
+test('.getAvatarUrl supports explicit user numeric input', t => {
+  t.is(
+    getAvatarUrl('user:94867603'),
+    'https://www.flickr.com/photos/94867603/'
   )
 })
 
@@ -23,10 +36,10 @@ test('.getAvatarUrl supports group path', t => {
   )
 })
 
-test('.getAvatarUrl supports groups NSID', t => {
+test('.getAvatarUrl supports groups numeric input', t => {
   t.is(
-    getAvatarUrl('groups:80641914@N00'),
-    'https://www.flickr.com/groups/80641914@N00/'
+    getAvatarUrl('groups:80641914'),
+    'https://www.flickr.com/groups/80641914/'
   )
 })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new provider behavior and external iTunes API query construction (lookup/search + country parsing) plus shared memoization logic, which could affect avatar resolution correctness and caching across providers.
> 
> **Overview**
> Adds a new **`apple-store` provider** that returns App Store/developer avatars via iTunes `lookup` (by app id, developer id, or bundle id) and iTunes `search` (by app/developer name), with optional `@cc` country scoping and explicit `type:value` inputs.
> 
> Extracts memoized iTunes Search fetching into `src/util/itunes-search.js` and updates `apple-music` to use it instead of inline memoization. Refactors `flickr` input parsing into helpers and updates unit tests accordingly, plus adds comprehensive tests for the new Apple Store provider (including memoization and fallback artwork sizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d120ffa1f00e70e6e487cc3da132ded460a2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->