### PR TITLE
chore: prefer prefixed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ It's proudly powered by [microlink.io](https://microlink.io/), the headless brow
 
 The service is exposed in **unavatar.io** via provider endpoints:
 
-- an **email (auto-detect)**: [unavatar.io/hello@microlink.io](https://unavatar.io/hello@microlink.io) — tries Gravatar, then GitHub
+- an **email**: [unavatar.io/email/hello@microlink.io](https://unavatar.io/email/hello@microlink.io)
+- a **domain**: [unavatar.io/domain/reddit.com](https://unavatar.io/domain/reddit.com)
 - an **email** via Gravatar: [unavatar.io/gravatar/hello@microlink.io](https://unavatar.io/gravatar/hello@microlink.io)
 - an **email** via GitHub: [unavatar.io/github/sindresorhus@gmail.com](https://unavatar.io/github/sindresorhus@gmail.com)
 - an **username**: [unavatar.io/github/kikobeats](https://unavatar.io/github/kikobeats)
 - a **domain**: [unavatar.io/google/reddit.com](https://unavatar.io/google/reddit.com)
 
-Use `/:provider/:key` for provider-specific lookups, or pass an email as the only path segment for automatic resolution. You can read more in [Email avatars](https://unavatar.io/email) and [providers](https://unavatar.io/docs#providers).
+Use `/email/:key` and `/domain/:key` for type-based resolution. You can read more in [Email avatars](https://unavatar.io/email) and [providers](https://unavatar.io/docs#providers).
 
 ## Authentication
 
@@ -651,7 +652,7 @@ Available inputs:
 
 ### YouTube
 
-Get any YouTube channel's thumbnail by their handle, legacy username, or channel ID.
+Get any YouTube channel's thumbnail by their handle, username, or channel ID.
 
 e.g., [unavatar.io/youtube/casey](https://unavatar.io/youtube/casey)
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -12,9 +12,9 @@ The package ships binaries that connect to a running unavatar server and display
 ## Examples
 
 ```bash
-# Auto-resolve
-unavatar hello@microlink.io
-unavatar reddit.com
+# Typed input routes
+unavatar email/hello@microlink.io
+unavatar domain/reddit.com
 
 # Specific provider
 unavatar github/kikobeats

--- a/docs/library/README.md
+++ b/docs/library/README.md
@@ -9,11 +9,14 @@ From [`./basic.js`](./basic.js):
 ```js
 const unavatar = require('@unavatar/core')()
 
-// Auto-resolve (detects email, domain, or username)
-const result = await unavatar('hello@microlink.io')
+// Resolve with explicit input type
+const result = await unavatar.email('hello@microlink.io')
+
+// Domain resolution
+const domainResult = await unavatar.domain('reddit.com')
 
 // Specific provider
-const result = await unavatar.github('kikobeats')
+const githubResult = await unavatar.github('kikobeats')
 ```
 
 Run it:

--- a/docs/library/basic.js
+++ b/docs/library/basic.js
@@ -3,12 +3,11 @@
 const unavatar = require('@unavatar/core')()
 
 async function main () {
-  // Auto-resolve: detects input type (email, domain, or username)
-  // and tries matching providers automatically
-  const fromEmail = await unavatar('hello@microlink.io')
+  // Explicit input type resolution
+  const fromEmail = await unavatar.email('hello@microlink.io')
   console.log('email →', fromEmail.data)
 
-  const fromDomain = await unavatar('reddit.com')
+  const fromDomain = await unavatar.domain('reddit.com')
   console.log('domain →', fromDomain.data)
 
   // Resolve from a specific provider

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -8,8 +8,8 @@ From [`./server.js`](./server.js).
 
 | Route                 | Description                                          |
 | --------------------- | ---------------------------------------------------- |
-| `GET /:provider/:key` | Resolve avatar from a specific provider              |
-| `GET /:key`           | Auto-resolve by input type (email, domain, username) |
+| `GET /email/:key`     | Resolve with email providers                         |
+| `GET /domain/:key`    | Resolve with domain providers                        |
 
 Append `?json` to any route to get the avatar URL as JSON instead of a `302` redirect.
 
@@ -23,11 +23,9 @@ node docs/server/server.js
 
 ```bash
 # Redirect to the avatar image
-curl -L http://localhost:3000/github/kikobeats
+curl -L http://localhost:3000/email/hello@microlink.io
 
-# Get the avatar URL as JSON
-curl http://localhost:3000/github/kikobeats?json
-
-# Auto-resolve from email
-curl http://localhost:3000/hello@microlink.io?json
+# Get the avatar URL as JSON from explicit input type
+curl http://localhost:3000/email/hello@microlink.io?json
+curl http://localhost:3000/domain/reddit.com?json
 ```

--- a/docs/server/server.js
+++ b/docs/server/server.js
@@ -20,8 +20,8 @@ const server = createServer(async (req, res) => {
     return sendJSON(res, 200, {
       providers: Object.keys(unavatar.providers),
       routes: [
-        'GET /:provider/:key — resolve avatar for a specific provider',
-        'GET /:key           — auto-resolve by input type (email, domain, username)'
+        'GET /email/:key     — resolve using email providers',
+        'GET /domain/:key    — resolve using domain providers'
       ]
     })
   }
@@ -30,14 +30,12 @@ const server = createServer(async (req, res) => {
     let result
 
     if (segments.length === 2) {
-      // GET /:provider/:key
       const [providerName, key] = segments
       if (!unavatar[providerName]) {
         return sendJSON(res, 404, { error: `Unknown provider: ${providerName}` })
       }
       result = await unavatar[providerName](key)
     } else {
-      // GET /:key — auto-resolve
       const [key] = segments
       result = await unavatar(key)
     }
@@ -66,7 +64,6 @@ server.listen(PORT, () => {
   console.log(`unavatar server listening on http://localhost:${PORT}`)
   console.log()
   console.log('Try:')
-  console.log(`  curl -L http://localhost:${PORT}/github/kikobeats`)
-  console.log(`  curl    http://localhost:${PORT}/github/kikobeats?json`)
-  console.log(`  curl    http://localhost:${PORT}/hello@microlink.io?json`)
+  console.log(`  curl    http://localhost:${PORT}/email/hello@microlink.io?json`)
+  console.log(`  curl    http://localhost:${PORT}/domain/reddit.com?json`)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,11 @@ module.exports = ({ constants: userConstants, redis, onFetchHTML } = {}) => {
     unavatar[name] = input => getAvatar(providers[name], name, input, {})
   })
 
+  const createTypedAutoResolver = inputType => input => auto(inputType)(input, {})
+
+  unavatar.email = createTypedAutoResolver('email')
+  unavatar.domain = createTypedAutoResolver('domain')
+
   unavatar.auto = auto
   unavatar.getInputType = getInputType
   unavatar.getAvatar = getAvatar

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const test = require('ava')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+test('supports explicit resolvers for email and domain while keeping direct input', async t => {
+  const githubProvider = sinon.stub()
+  const getInputType = sinon.stub().returns('email')
+  const getAvatar = sinon.stub().resolves({
+    type: 'url',
+    data: 'https://example.com/github.png',
+    provider: 'github'
+  })
+
+  const resolversByType = {
+    email: sinon.stub().resolves({
+      type: 'url',
+      data: 'https://example.com/email.png',
+      provider: 'gravatar'
+    }),
+    domain: sinon.stub().resolves({
+      type: 'url',
+      data: 'https://example.com/domain.png',
+      provider: 'microlink'
+    })
+  }
+
+  const auto = sinon.stub().callsFake(inputType => resolversByType[inputType])
+
+  const createUnavatar = proxyquire('../../src/index', {
+    './constant': {},
+    './util/keyv': () => ({
+      createMultiCache: sinon.stub(),
+      createRedisCache: sinon.stub()
+    }),
+    './util/cache': () => ({
+      dnsCache: {},
+      pingCache: {},
+      githubSearchCache: {},
+      itunesSearchCache: {}
+    }),
+    './util/cacheable-lookup': () => ({}),
+    './util/is-reserved-ip': () => ({}),
+    './util/got': () => ({}),
+    './util/reachable-url': () => ({}),
+    './util/browserless': () => () => ({}),
+    './util/html-get': () => () => ({}),
+    './util/html-provider': () => ({
+      createHtmlProvider: sinon.stub(),
+      getOgImage: sinon.stub(),
+      NOT_FOUND: Symbol('NOT_FOUND')
+    }),
+    './providers': () => ({
+      providers: { github: githubProvider },
+      providersBy: { email: ['gravatar'], domain: ['microlink'], username: [] }
+    }),
+    './avatar/auto': () => ({ auto, getInputType, getAvatar })
+  })
+
+  const unavatar = createUnavatar()
+
+  t.is(typeof unavatar.email, 'function')
+  t.is(typeof unavatar.domain, 'function')
+
+  await unavatar.email('hello@microlink.io')
+  await unavatar.domain('facebook.com')
+  await unavatar('hello@example.com')
+  await unavatar.github('kikobeats')
+
+  t.is(auto.callCount, 3)
+  t.deepEqual(auto.getCall(0).args, ['email'])
+  t.deepEqual(auto.getCall(1).args, ['domain'])
+  t.deepEqual(auto.getCall(2).args, ['email'])
+
+  t.deepEqual(resolversByType.email.getCall(0).args, ['hello@microlink.io', {}])
+  t.deepEqual(resolversByType.domain.getCall(0).args, ['facebook.com', {}])
+  t.deepEqual(resolversByType.email.getCall(1).args, ['hello@example.com', {}])
+
+  t.true(getInputType.calledOnceWithExactly('hello@example.com'))
+  t.true(getAvatar.calledOnceWithExactly(githubProvider, 'github', 'kikobeats', {}))
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive API change (new helper methods) plus documentation updates; minimal behavioral impact as existing resolution paths remain supported, but downstream consumers may follow the new preferred routes.
> 
> **Overview**
> Updates public usage to prefer *type-prefixed* resolution (`/email/:key`, `/domain/:key`) instead of passing raw values for auto-detection, across the main README and CLI/library/server docs.
> 
> In `@unavatar/core`, adds explicit typed helpers `unavatar.email()` and `unavatar.domain()` (wrapping the existing auto resolver) while keeping the existing direct-call auto-detection and provider-specific methods; includes a new unit test to validate the new API surface and that existing behavior remains intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d9dfd77e2817cc026538602a207d5857071c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->