### PR TITLE
chore(stackoverflow): drop slug

### DIFF
--- a/src/providers/stackoverflow.js
+++ b/src/providers/stackoverflow.js
@@ -2,16 +2,14 @@
 
 const AVATAR_SELECTOR = '.js-usermini-avatar-container img'
 
-const normalizeInput = input => {
-  let normalizedInput = input.replace(/^\/+/, '')
-  if (normalizedInput.startsWith('users/')) {
-    normalizedInput = normalizedInput.slice('users/'.length)
-  }
-  return normalizedInput
-}
+const normalizeUserId = input =>
+  input
+    .replace(/^\/+/, '')
+    .replace(/^users\//, '')
+    .split('/')[0]
 
 const getProfileUrl = input =>
-  `https://stackoverflow.com/users/${normalizeInput(input)}`
+  `https://stackoverflow.com/users/${normalizeUserId(input)}`
 
 const getAvatarUrl = $ =>
   $(`${AVATAR_SELECTOR}[width="128"]`).attr('src') ||

--- a/test/unit/providers/stackoverflow.js
+++ b/test/unit/providers/stackoverflow.js
@@ -5,24 +5,21 @@ const test = require('ava')
 
 const { getProfileUrl, getAvatarUrl } = require('../../../src/providers/stackoverflow')
 
-test('.getProfileUrl builds users URL', t => {
-  t.is(
-    getProfileUrl('19082/mike-hordecki'),
-    'https://stackoverflow.com/users/19082/mike-hordecki'
-  )
+test('.getProfileUrl builds users URL from ID', t => {
+  t.is(getProfileUrl('576911'), 'https://stackoverflow.com/users/576911')
 })
 
 test('.getProfileUrl supports input prefixed with users/', t => {
   t.is(
-    getProfileUrl('users/19082/mike-hordecki'),
-    'https://stackoverflow.com/users/19082/mike-hordecki'
+    getProfileUrl('users/576911'),
+    'https://stackoverflow.com/users/576911'
   )
 })
 
-test('.getProfileUrl removes leading slash', t => {
+test('.getProfileUrl keeps only user ID when a slug is present', t => {
   t.is(
-    getProfileUrl('/users/19082/mike-hordecki'),
-    'https://stackoverflow.com/users/19082/mike-hordecki'
+    getProfileUrl('/users/576911/example-slug'),
+    'https://stackoverflow.com/users/576911'
   )
 })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk string-parsing change limited to StackOverflow profile URL generation, with updated unit tests covering the new normalization behavior.
> 
> **Overview**
> The StackOverflow provider now **extracts only the numeric user ID** from inputs (handling leading slashes, optional `users/` prefix, and dropping any trailing slug) and always generates profile URLs as `https://stackoverflow.com/users/<id>`.
> 
> Unit tests were updated to assert the new behavior (ID-only URLs and slug-stripping), while avatar scraping logic remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb7d58303317cf87b037a0ec11d546af2af58d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->