### PR TITLE
chore(apple-store): drop dev type

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -11,7 +11,7 @@ module.exports = ({ baseUrl }) => {
     alias: { H: 'header' }
   })
 
-  const [input] = _
+  const input = _.join(' ')
 
   const parseHeaders = raw => {
     const entries = raw == null ? [] : Array.isArray(raw) ? raw : [raw]

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -72,7 +72,7 @@ const getAppAvatar = async ({ got, id, country }) => {
 const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
   const getSearchResults = searchResults || createGetSearchResults({ got })
   const query = withCountry({
-    query: `term=${encodeURIComponent(name)}&entity=software&limit=1`,
+    query: `term=${encodeURIComponent(name)}&entity=software&limit=5`,
     country
   })
   const results = await getSearchResults(query)

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -13,7 +13,7 @@ const withCountry = ({ query, country }) =>
 
 const parseInput = input => {
   const separatorIndex = input.indexOf(':')
-  if (separatorIndex === -1) return { type: 'app', value: input }
+  if (separatorIndex === -1) return { type: 'id', value: input }
 
   return {
     type: input.slice(0, separatorIndex),
@@ -81,11 +81,11 @@ module.exports = ({ got, itunesSearchCache }) => {
     const { value, country } = parseCountry(rawValue)
 
     switch (type) {
-      case 'app':
+      case 'id':
         return getAppAvatar({ got, id: value, country })
       case 'bundle':
         return getBundleAvatar({ got, bundleId: value, country })
-      case 'app-name':
+      case 'name':
         return getAppNameAvatar({ got, name: value, country, searchResults })
       default:
         throw new Error(`Unsupported Apple Store type: ${type}`)

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -54,16 +54,6 @@ const getAppAvatar = async ({ got, id, country }) => {
   return getArtworkUrl(result)
 }
 
-const getDeveloperAvatar = async ({ got, id, country }) => {
-  const query = withCountry({
-    query: `id=${encodeURIComponent(id)}&entity=software&limit=200`,
-    country
-  })
-  const results = await getLookupResults({ got, query })
-  const softwareResult = results.find(result => result?.kind === 'software')
-  return getArtworkUrl(softwareResult)
-}
-
 const getBundleAvatar = async ({ got, bundleId, country }) => {
   const query = withCountry({
     query: `bundleId=${encodeURIComponent(bundleId)}&entity=software&limit=1`,
@@ -83,7 +73,12 @@ const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
   return getArtworkUrl(result)
 }
 
-const getDeveloperNameAvatar = async ({ got, name, country, searchResults }) => {
+const getDeveloperNameAvatar = async ({
+  got,
+  name,
+  country,
+  searchResults
+}) => {
   const getSearchResults = searchResults || createGetSearchResults({ got })
   const query = withCountry({
     query: `term=${encodeURIComponent(
@@ -105,14 +100,17 @@ module.exports = ({ got, itunesSearchCache }) => {
     switch (type) {
       case 'app':
         return getAppAvatar({ got, id: value, country })
-      case 'dev':
-        return getDeveloperAvatar({ got, id: value, country })
       case 'bundle':
         return getBundleAvatar({ got, bundleId: value, country })
       case 'app-name':
         return getAppNameAvatar({ got, name: value, country, searchResults })
       case 'dev-name':
-        return getDeveloperNameAvatar({ got, name: value, country, searchResults })
+        return getDeveloperNameAvatar({
+          got,
+          name: value,
+          country,
+          searchResults
+        })
       default:
         throw new Error(`Unsupported Apple Store type: ${type}`)
     }
@@ -120,7 +118,6 @@ module.exports = ({ got, itunesSearchCache }) => {
 }
 
 module.exports.getAppAvatar = getAppAvatar
-module.exports.getDeveloperAvatar = getDeveloperAvatar
 module.exports.getBundleAvatar = getBundleAvatar
 module.exports.getAppNameAvatar = getAppNameAvatar
 module.exports.getDeveloperNameAvatar = getDeveloperNameAvatar

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -8,6 +8,21 @@ const COUNTRY_CODE_REGEX = /^[a-z]{2}$/i
 const getArtworkUrl = result =>
   result?.artworkUrl512 || result?.artworkUrl100 || result?.artworkUrl60
 
+const normalizeName = value =>
+  typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/\s+/g, ' ')
+    : ''
+
+const isAppNameMatch = ({ result, name }) => {
+  const query = normalizeName(name)
+  if (!query) return false
+
+  const trackName = normalizeName(result?.trackName)
+  const trackCensoredName = normalizeName(result?.trackCensoredName)
+
+  return trackName === query || trackCensoredName === query
+}
+
 const withCountry = ({ query, country }) =>
   country ? `${query}&country=${encodeURIComponent(country)}` : query
 
@@ -54,22 +69,14 @@ const getAppAvatar = async ({ got, id, country }) => {
   return getArtworkUrl(result)
 }
 
-const getBundleAvatar = async ({ got, bundleId, country }) => {
-  const query = withCountry({
-    query: `bundleId=${encodeURIComponent(bundleId)}&entity=software&limit=1`,
-    country
-  })
-  const [result] = await getLookupResults({ got, query })
-  return getArtworkUrl(result)
-}
-
 const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
   const getSearchResults = searchResults || createGetSearchResults({ got })
   const query = withCountry({
     query: `term=${encodeURIComponent(name)}&entity=software&limit=1`,
     country
   })
-  const [result] = await getSearchResults(query)
+  const results = await getSearchResults(query)
+  const result = results.find(result => isAppNameMatch({ result, name }))
   return getArtworkUrl(result)
 }
 
@@ -83,8 +90,6 @@ module.exports = ({ got, itunesSearchCache }) => {
     switch (type) {
       case 'id':
         return getAppAvatar({ got, id: value, country })
-      case 'bundle':
-        return getBundleAvatar({ got, bundleId: value, country })
       case 'name':
         return getAppNameAvatar({ got, name: value, country, searchResults })
       default:
@@ -94,5 +99,4 @@ module.exports = ({ got, itunesSearchCache }) => {
 }
 
 module.exports.getAppAvatar = getAppAvatar
-module.exports.getBundleAvatar = getBundleAvatar
 module.exports.getAppNameAvatar = getAppNameAvatar

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -81,7 +81,7 @@ const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
     country
   })
   const results = await getSearchResults(query)
-  const result = results.find(result => isAppNameMatch({ result, name }))
+  const result = results.find(item => isAppNameMatch({ result: item, name }))
   return getArtworkUrl(result)
 }
 

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -10,7 +10,12 @@ const getArtworkUrl = result =>
 
 const normalizeName = value =>
   typeof value === 'string'
-    ? value.trim().toLowerCase().replace(/\s+/g, ' ')
+    ? value
+      .trim()
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\s+/g, ' ')
     : ''
 
 const isAppNameMatch = ({ result, name }) => {

--- a/src/providers/apple-store.js
+++ b/src/providers/apple-store.js
@@ -73,23 +73,6 @@ const getAppNameAvatar = async ({ got, name, country, searchResults }) => {
   return getArtworkUrl(result)
 }
 
-const getDeveloperNameAvatar = async ({
-  got,
-  name,
-  country,
-  searchResults
-}) => {
-  const getSearchResults = searchResults || createGetSearchResults({ got })
-  const query = withCountry({
-    query: `term=${encodeURIComponent(
-      name
-    )}&entity=software&attribute=softwareDeveloper&limit=1`,
-    country
-  })
-  const [result] = await getSearchResults(query)
-  return getArtworkUrl(result)
-}
-
 module.exports = ({ got, itunesSearchCache }) => {
   const searchResults = createGetSearchResults({ got, itunesSearchCache })
 
@@ -104,13 +87,6 @@ module.exports = ({ got, itunesSearchCache }) => {
         return getBundleAvatar({ got, bundleId: value, country })
       case 'app-name':
         return getAppNameAvatar({ got, name: value, country, searchResults })
-      case 'dev-name':
-        return getDeveloperNameAvatar({
-          got,
-          name: value,
-          country,
-          searchResults
-        })
       default:
         throw new Error(`Unsupported Apple Store type: ${type}`)
     }
@@ -120,4 +96,3 @@ module.exports = ({ got, itunesSearchCache }) => {
 module.exports.getAppAvatar = getAppAvatar
 module.exports.getBundleAvatar = getBundleAvatar
 module.exports.getAppNameAvatar = getAppNameAvatar
-module.exports.getDeveloperNameAvatar = getDeveloperNameAvatar

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -6,8 +6,7 @@ const Keyv = require('@keyvhq/core')
 const {
   getAppAvatar,
   getBundleAvatar,
-  getAppNameAvatar,
-  getDeveloperNameAvatar
+  getAppNameAvatar
 } = require('../../../src/providers/apple-store')
 
 test('apple-store provider defaults to app type', async t => {
@@ -115,25 +114,6 @@ test('apple-store provider memoizes app-name iTunes search lookups', async t => 
   t.is(gotCalls, 1)
 })
 
-test('apple-store provider supports dev-name search with country', async t => {
-  const provider = require('../../../src/providers/apple-store')({
-    got: async (url, opts) => {
-      t.is(
-        url,
-        'https://itunes.apple.com/search?term=meta%20platforms&entity=software&attribute=softwareDeveloper&limit=1&country=gb'
-      )
-      t.is(opts.responseType, 'json')
-      t.true(opts.resolveBodyOnly)
-      return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/dev-name.jpg' }]
-      }
-    }
-  })
-
-  const avatarUrl = await provider('dev-name:meta platforms@gb')
-  t.is(avatarUrl, 'https://cdn.apple.com/dev-name.jpg')
-})
-
 test('apple-store provider throws for unsupported app-url type', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async () => ({ results: [] })
@@ -152,6 +132,24 @@ test('apple-store provider throws for unsupported type', async t => {
 
   const error = await t.throwsAsync(async () => provider('genre:action'))
   t.is(error.message, 'Unsupported Apple Store type: genre')
+})
+
+test('apple-store provider throws for dev type', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [] })
+  })
+
+  const error = await t.throwsAsync(async () => provider('dev:488106216'))
+  t.is(error.message, 'Unsupported Apple Store type: dev')
+})
+
+test('apple-store provider throws for dev-name type', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [] })
+  })
+
+  const error = await t.throwsAsync(async () => provider('dev-name:supercell'))
+  t.is(error.message, 'Unsupported Apple Store type: dev-name')
 })
 
 test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', async t => {
@@ -178,15 +176,6 @@ test('getAppNameAvatar returns undefined when search is empty', async t => {
   const avatarUrl = await getAppNameAvatar({
     got: async () => ({ results: [] }),
     name: 'missing-app'
-  })
-
-  t.is(avatarUrl, undefined)
-})
-
-test('getDeveloperNameAvatar returns undefined when search is empty', async t => {
-  const avatarUrl = await getDeveloperNameAvatar({
-    got: async () => ({ results: [] }),
-    name: 'missing-dev'
   })
 
   t.is(avatarUrl, undefined)

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -61,7 +61,7 @@ test('apple-store provider supports exact name search', async t => {
     got: async (url, opts) => {
       t.is(
         url,
-        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=1'
+        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=5'
       )
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
@@ -89,7 +89,7 @@ test('apple-store provider memoizes name iTunes search lookups', async t => {
       gotCalls++
       t.is(
         url,
-        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=1'
+        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=5'
       )
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -5,11 +5,10 @@ const Keyv = require('@keyvhq/core')
 
 const {
   getAppAvatar,
-  getBundleAvatar,
   getAppNameAvatar
 } = require('../../../src/providers/apple-store')
 
-test('apple-store provider defaults to app type', async t => {
+test('apple-store provider defaults to id type', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async (url, opts) => {
       t.is(
@@ -33,7 +32,7 @@ test('apple-store provider defaults to app type', async t => {
   t.is(avatarUrl, 'https://cdn.apple.com/app-512.jpg')
 })
 
-test('apple-store provider supports explicit app type with country', async t => {
+test('apple-store provider supports explicit id type with country', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async (url, opts) => {
       t.is(
@@ -53,46 +52,24 @@ test('apple-store provider supports explicit app type with country', async t => 
     }
   })
 
-  const avatarUrl = await provider('app:310633997@es')
+  const avatarUrl = await provider('id:310633997@es')
   t.is(avatarUrl, 'https://cdn.apple.com/app-es.jpg')
 })
 
-test('apple-store provider supports bundle id lookups', async t => {
+test('apple-store provider supports exact name search', async t => {
   const provider = require('../../../src/providers/apple-store')({
     got: async (url, opts) => {
       t.is(
         url,
-        'https://itunes.apple.com/lookup?bundleId=com.facebook.Facebook&entity=software&limit=1'
+        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=1'
       )
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
         results: [
           {
-            kind: 'software',
-            artworkUrl512: 'https://cdn.apple.com/bundle.jpg'
-          }
-        ]
-      }
-    }
-  })
-
-  const avatarUrl = await provider('bundle:com.facebook.Facebook')
-  t.is(avatarUrl, 'https://cdn.apple.com/bundle.jpg')
-})
-
-test('apple-store provider supports app-name search', async t => {
-  const provider = require('../../../src/providers/apple-store')({
-    got: async (url, opts) => {
-      t.is(
-        url,
-        'https://itunes.apple.com/search?term=whatsapp&entity=software&limit=1'
-      )
-      t.is(opts.responseType, 'json')
-      t.true(opts.resolveBodyOnly)
-      return {
-        results: [
-          {
+            trackName: 'WhatsApp Messenger',
+            trackCensoredName: 'WhatsApp Messenger',
             kind: 'software',
             artworkUrl512: 'https://cdn.apple.com/app-name.jpg'
           }
@@ -101,24 +78,26 @@ test('apple-store provider supports app-name search', async t => {
     }
   })
 
-  const avatarUrl = await provider('app-name:whatsapp')
+  const avatarUrl = await provider('name:whatsapp messenger')
   t.is(avatarUrl, 'https://cdn.apple.com/app-name.jpg')
 })
 
-test('apple-store provider memoizes app-name iTunes search lookups', async t => {
+test('apple-store provider memoizes name iTunes search lookups', async t => {
   let gotCalls = 0
   const provider = require('../../../src/providers/apple-store')({
     got: async (url, opts) => {
       gotCalls++
       t.is(
         url,
-        'https://itunes.apple.com/search?term=whatsapp&entity=software&limit=1'
+        'https://itunes.apple.com/search?term=whatsapp%20messenger&entity=software&limit=1'
       )
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
         results: [
           {
+            trackName: 'WhatsApp Messenger',
+            trackCensoredName: 'WhatsApp Messenger',
             kind: 'software',
             artworkUrl512: 'https://cdn.apple.com/app-name.jpg'
           }
@@ -131,12 +110,31 @@ test('apple-store provider memoizes app-name iTunes search lookups', async t => 
     })
   })
 
-  const first = await provider('app-name:whatsapp')
-  const second = await provider('app-name:whatsapp')
+  const first = await provider('name:whatsapp messenger')
+  const second = await provider('name:whatsapp messenger')
 
   t.is(first, 'https://cdn.apple.com/app-name.jpg')
   t.is(second, 'https://cdn.apple.com/app-name.jpg')
   t.is(gotCalls, 1)
+})
+
+test('apple-store provider returns undefined when only partial matches exist', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({
+      results: [
+        {
+          kind: 'software',
+          trackName: 'Supercell Network',
+          trackCensoredName: 'Supercell Network',
+          artistName: 'Supercell',
+          artworkUrl512: 'https://cdn.apple.com/supercell-network.jpg'
+        }
+      ]
+    })
+  })
+
+  const avatarUrl = await provider('name:supercell')
+  t.is(avatarUrl, undefined)
 })
 
 test('apple-store provider throws for unsupported app-url type', async t => {
@@ -177,6 +175,17 @@ test('apple-store provider throws for dev-name type', async t => {
   t.is(error.message, 'Unsupported Apple Store type: dev-name')
 })
 
+test('apple-store provider throws for bundle type', async t => {
+  const provider = require('../../../src/providers/apple-store')({
+    got: async () => ({ results: [] })
+  })
+
+  const error = await t.throwsAsync(async () =>
+    provider('bundle:com.spotify.client')
+  )
+  t.is(error.message, 'Unsupported Apple Store type: bundle')
+})
+
 test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', async t => {
   const avatarUrl = await getAppAvatar({
     got: async () => ({
@@ -188,15 +197,6 @@ test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', a
   })
 
   t.is(avatarUrl, 'https://cdn.apple.com/app-100.jpg')
-})
-
-test('getBundleAvatar returns undefined when lookup is empty', async t => {
-  const avatarUrl = await getBundleAvatar({
-    got: async () => ({ results: [] }),
-    bundleId: 'com.example.missing'
-  })
-
-  t.is(avatarUrl, undefined)
 })
 
 test('getAppNameAvatar returns undefined when search is empty', async t => {
@@ -213,7 +213,7 @@ test('apple-store provider returns undefined when lookup has no software results
     got: async () => ({ results: [{ wrapperType: 'artist', artistId: 1 }] })
   })
 
-  const appAvatar = await provider('app:999')
+  const appAvatar = await provider('id:999')
 
   t.is(appAvatar, undefined)
 })

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -5,7 +5,6 @@ const Keyv = require('@keyvhq/core')
 
 const {
   getAppAvatar,
-  getDeveloperAvatar,
   getBundleAvatar,
   getAppNameAvatar,
   getDeveloperNameAvatar
@@ -47,28 +46,6 @@ test('apple-store provider supports explicit app type with country', async t => 
 
   const avatarUrl = await provider('app:310633997@es')
   t.is(avatarUrl, 'https://cdn.apple.com/app-es.jpg')
-})
-
-test('apple-store provider supports explicit dev type with country', async t => {
-  const provider = require('../../../src/providers/apple-store')({
-    got: async (url, opts) => {
-      t.is(
-        url,
-        'https://itunes.apple.com/lookup?id=284882218&entity=software&limit=200&country=us'
-      )
-      t.is(opts.responseType, 'json')
-      t.true(opts.resolveBodyOnly)
-      return {
-        results: [
-          { wrapperType: 'artist', artistId: 284882218 },
-          { kind: 'software', artworkUrl512: 'https://cdn.apple.com/dev-app.jpg' }
-        ]
-      }
-    }
-  })
-
-  const avatarUrl = await provider('dev:284882218@US')
-  t.is(avatarUrl, 'https://cdn.apple.com/dev-app.jpg')
 })
 
 test('apple-store provider supports bundle id lookups', async t => {
@@ -188,17 +165,6 @@ test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', a
   t.is(avatarUrl, 'https://cdn.apple.com/app-100.jpg')
 })
 
-test('getDeveloperAvatar falls back to artworkUrl60 when artworkUrl512 is missing', async t => {
-  const avatarUrl = await getDeveloperAvatar({
-    got: async () => ({
-      results: [{ kind: 'software', artworkUrl60: 'https://cdn.apple.com/dev-60.jpg' }]
-    }),
-    id: '310634000'
-  })
-
-  t.is(avatarUrl, 'https://cdn.apple.com/dev-60.jpg')
-})
-
 test('getBundleAvatar returns undefined when lookup is empty', async t => {
   const avatarUrl = await getBundleAvatar({
     got: async () => ({ results: [] }),
@@ -232,8 +198,6 @@ test('apple-store provider returns undefined when lookup has no software results
   })
 
   const appAvatar = await provider('app:999')
-  const devAvatar = await provider('dev:999')
 
   t.is(appAvatar, undefined)
-  t.is(devAvatar, undefined)
 })

--- a/test/unit/providers/apple-store.js
+++ b/test/unit/providers/apple-store.js
@@ -19,7 +19,12 @@ test('apple-store provider defaults to app type', async t => {
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-512.jpg' }]
+        results: [
+          {
+            kind: 'software',
+            artworkUrl512: 'https://cdn.apple.com/app-512.jpg'
+          }
+        ]
       }
     }
   })
@@ -38,7 +43,12 @@ test('apple-store provider supports explicit app type with country', async t => 
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-es.jpg' }]
+        results: [
+          {
+            kind: 'software',
+            artworkUrl512: 'https://cdn.apple.com/app-es.jpg'
+          }
+        ]
       }
     }
   })
@@ -57,7 +67,12 @@ test('apple-store provider supports bundle id lookups', async t => {
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/bundle.jpg' }]
+        results: [
+          {
+            kind: 'software',
+            artworkUrl512: 'https://cdn.apple.com/bundle.jpg'
+          }
+        ]
       }
     }
   })
@@ -76,7 +91,12 @@ test('apple-store provider supports app-name search', async t => {
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-name.jpg' }]
+        results: [
+          {
+            kind: 'software',
+            artworkUrl512: 'https://cdn.apple.com/app-name.jpg'
+          }
+        ]
       }
     }
   })
@@ -97,7 +117,12 @@ test('apple-store provider memoizes app-name iTunes search lookups', async t => 
       t.is(opts.responseType, 'json')
       t.true(opts.resolveBodyOnly)
       return {
-        results: [{ kind: 'software', artworkUrl512: 'https://cdn.apple.com/app-name.jpg' }]
+        results: [
+          {
+            kind: 'software',
+            artworkUrl512: 'https://cdn.apple.com/app-name.jpg'
+          }
+        ]
       }
     },
     itunesSearchCache: new Keyv({
@@ -155,7 +180,9 @@ test('apple-store provider throws for dev-name type', async t => {
 test('getAppAvatar falls back to artworkUrl100 when artworkUrl512 is missing', async t => {
   const avatarUrl = await getAppAvatar({
     got: async () => ({
-      results: [{ kind: 'software', artworkUrl100: 'https://cdn.apple.com/app-100.jpg' }]
+      results: [
+        { kind: 'software', artworkUrl100: 'https://cdn.apple.com/app-100.jpg' }
+      ]
     }),
     id: '389801252'
   })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Behavior is intentionally breaking for Apple Store inputs (`app`→`id`, `app-name`→`name`, and `dev`/`bundle` removed), which may impact existing consumers relying on the old types.
> 
> **Overview**
> The Apple Store provider is narrowed to only support `id` lookups and `name` searches: it now defaults to `id` when no type is given, removes `dev`, `dev-name`, and `bundle` support/exports, and updates tests to assert these types now throw.
> 
> `name` lookups now fetch up to 5 iTunes search results and return an avatar only when an *exact* normalized match is found (case/whitespace/diacritics-insensitive), returning `undefined` for partial matches. Separately, the CLI now joins all positional args (`_.join(' ')`) so inputs containing spaces are handled correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8262a6122ed049cf3445503a88c1ef4a98911f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->