### PR TITLE
refactor: unify functio names

### DIFF
--- a/src/providers/buymeacoffee.js
+++ b/src/providers/buymeacoffee.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const getAvatarUrl = $ => {
+const getAvatar = $ => {
   const dataPage = $('#app').attr('data-page')
   if (!dataPage) return
 
@@ -16,9 +16,9 @@ const factory = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'buymeacoffee',
     url: input => `https://buymeacoffee.com/${input}`,
-    getter: getAvatarUrl
+    getter: getAvatar
   })
 
-factory.getAvatarUrl = getAvatarUrl
+factory.getAvatar = getAvatar
 
 module.exports = factory

--- a/src/providers/dockerhub.js
+++ b/src/providers/dockerhub.js
@@ -2,11 +2,11 @@
 
 const API_URL = 'https://hub.docker.com/v2/users'
 
-const getUserUrl = input => `${API_URL}/${encodeURIComponent(input)}/`
+const getAvatarUrl = input => `${API_URL}/${encodeURIComponent(input)}/`
 
 module.exports = ({ got }) =>
   async function dockerhub (input) {
-    const { body, statusCode } = await got(getUserUrl(input), {
+    const { body, statusCode } = await got(getAvatarUrl(input), {
       responseType: 'json',
       throwHttpErrors: false
     })
@@ -16,4 +16,4 @@ module.exports = ({ got }) =>
     return body?.gravatar_url || undefined
   }
 
-module.exports.getUserUrl = getUserUrl
+module.exports.getAvatarUrl = getAvatarUrl

--- a/src/providers/flickr.js
+++ b/src/providers/flickr.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const BUDDY_ICON_URL_PATTERN = /(?:https?:)?\/\/[^"'()\s]*\/buddyicons\/[^"'()\s]+/i
+const BUDDY_ICON_URL_PATTERN =
+  /(?:https?:)?\/\/[^"'()\s]*\/buddyicons\/[^"'()\s]+/i
 const CSS_URL_PATTERN = /url\((['"]?)([^)'"]+)\1\)/i
 const unescapePathSlashes = value => value?.replace(/\\\//g, '/')
 
@@ -19,7 +20,8 @@ const getBuddyIconFromText = value => {
 }
 
 const getUserProfileUrl = userId => `https://www.flickr.com/photos/${userId}/`
-const getGroupProfileUrl = groupId => `https://www.flickr.com/groups/${groupId}/`
+const getGroupProfileUrl = groupId =>
+  `https://www.flickr.com/groups/${groupId}/`
 
 const getAvatarUrl = input => {
   const { type, id } = parseInput(input)
@@ -41,7 +43,7 @@ const getBuddyIconFromCss = value => {
   return getBuddyIconFromText(cssUrl)
 }
 
-const getAvatarFromMarkup = $ => {
+const getAvatar = $ => {
   const imgBuddyIcon = $('img[src*="/buddyicons/"]').first().attr('src')
   if (imgBuddyIcon) return imgBuddyIcon
 
@@ -57,8 +59,8 @@ module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'flickr',
     url: getAvatarUrl,
-    getter: getAvatarFromMarkup
+    getter: getAvatar
   })
 
 module.exports.getAvatarUrl = getAvatarUrl
-module.exports.getAvatarFromMarkup = getAvatarFromMarkup
+module.exports.getAvatar = getAvatar

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -12,8 +12,9 @@ const COMMIT_SEARCH_ACCEPT_HEADER = 'application/vnd.github+json'
 const normalizeValue = value =>
   typeof value === 'string' ? value.trim().toLowerCase() : ''
 const getSearchItems = body => body?.items ?? []
-const getUniqueLogins = candidates =>
-  [...new Set(candidates.map(({ login }) => login).filter(Boolean))]
+const getUniqueLogins = candidates => [
+  ...new Set(candidates.map(({ login }) => login).filter(Boolean))
+]
 
 const fetchJsonBody = async ({ got, url, options }) => {
   const { body } = await got(url, {
@@ -38,21 +39,22 @@ const pickLinkedUser = item => {
   if (isResolvablePerson(item.committer)) return item.committer
 }
 
-const getUsernameAvatarUrl = ({ constants, input }) =>
+const getAvatarUrl = ({ constants, input }) =>
   `https://github.com/${input}.png?${stringify({
     size: constants.AVATAR_SIZE
   })}`
 
-const createSearchUsersByEmail = ({ got }) =>
-  async email => {
-    const body = await fetchJsonBody({
-      got,
-      url: `${GITHUB_API_URL}/search/users?q=${encodeURIComponent(
+const createSearchUsersByEmail =
+  ({ got }) =>
+    async email => {
+      const body = await fetchJsonBody({
+        got,
+        url: `${GITHUB_API_URL}/search/users?q=${encodeURIComponent(
         email
       )}&per_page=${SEARCH_USERS_PER_PAGE}`
-    })
-    return getSearchItems(body)
-  }
+      })
+      return getSearchItems(body)
+    }
 
 const createGetUser = ({ githubSearchCache, got }) =>
   memoize(
@@ -65,20 +67,21 @@ const createGetUser = ({ githubSearchCache, got }) =>
     { key: login => `user:${normalizeValue(login)}` }
   )
 
-const createSearchCommitsByEmail = ({ got }) =>
-  async email => {
-    const body = await fetchJsonBody({
-      got,
-      url: `${GITHUB_API_URL}/search/commits?q=${encodeURIComponent(
+const createSearchCommitsByEmail =
+  ({ got }) =>
+    async email => {
+      const body = await fetchJsonBody({
+        got,
+        url: `${GITHUB_API_URL}/search/commits?q=${encodeURIComponent(
         `author-email:${email}`
       )}&per_page=${SEARCH_COMMITS_PER_PAGE}`,
-      options: {
-        headers: { accept: COMMIT_SEARCH_ACCEPT_HEADER }
-      }
-    })
+        options: {
+          headers: { accept: COMMIT_SEARCH_ACCEPT_HEADER }
+        }
+      })
 
-    return getSearchItems(body)
-  }
+      return getSearchItems(body)
+    }
 
 const findExactPublicProfileMatches = async ({
   email,
@@ -156,7 +159,7 @@ module.exports = ({ constants, githubSearchCache, got }) => {
   const searchCommitsByEmail = createSearchCommitsByEmail({ got })
 
   return async function github (input) {
-    if (!isEmail(input)) return getUsernameAvatarUrl({ constants, input })
+    if (!isEmail(input)) return getAvatarUrl({ constants, input })
     const email = normalizeValue(input)
 
     // Strategy: exact public user email -> user commit consensus ->
@@ -180,6 +183,6 @@ module.exports = ({ constants, githubSearchCache, got }) => {
   }
 }
 
-module.exports.getUsernameAvatarUrl = getUsernameAvatarUrl
+module.exports.getAvatarUrl = getAvatarUrl
 module.exports.findExactPublicProfileMatches = findExactPublicProfileMatches
 module.exports.findCommitConsensusMatch = findCommitConsensusMatch

--- a/src/providers/ko-fi.js
+++ b/src/providers/ko-fi.js
@@ -1,14 +1,14 @@
 'use strict'
 
-const getAvatarUrl = $ => $('img#profilePicture').attr('src')
+const getAvatar = $ => $('img#profilePicture').attr('src')
 
 const factory = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'ko-fi',
     url: input => `https://ko-fi.com/${input}`,
-    getter: getAvatarUrl
+    getter: getAvatar
   })
 
-factory.getAvatarUrl = getAvatarUrl
+factory.getAvatar = getAvatar
 
 module.exports = factory

--- a/src/providers/mastodon.js
+++ b/src/providers/mastodon.js
@@ -17,7 +17,7 @@ const isValidServer = server => {
   }
 }
 
-const parseMastodonInput = input => {
+const parseInput = input => {
   if (typeof input !== 'string') return
 
   const cleaned = input.startsWith('@') ? input.slice(1) : input
@@ -36,7 +36,7 @@ const parseMastodonInput = input => {
 
 module.exports = ({ got, isReservedIp }) => {
   const mastodon = async function (input) {
-    const parsed = parseMastodonInput(input)
+    const parsed = parseInput(input)
     if (!parsed) return
 
     const { username, server } = parsed
@@ -56,4 +56,4 @@ module.exports = ({ got, isReservedIp }) => {
   return mastodon
 }
 
-module.exports.parseMastodonInput = parseMastodonInput
+module.exports.parseInput = parseInput

--- a/src/providers/onlyfans.js
+++ b/src/providers/onlyfans.js
@@ -2,7 +2,7 @@
 
 const { get } = require('lodash')
 
-const getAvatarUrl = $ => {
+const getAvatar = $ => {
   const text = $('script[type="application/ld+json"]').contents().text()
   return text ? get(JSON.parse(text), 'mainEntity.image') : undefined
 }
@@ -11,7 +11,7 @@ module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'onlyfans',
     url: input => `https://onlyfans.com/${input}`,
-    getter: getAvatarUrl,
+    getter: getAvatar,
     htmlOpts: () => ({
       prerender: true,
       puppeteerOpts: {
@@ -21,4 +21,4 @@ module.exports = ({ createHtmlProvider }) =>
     })
   })
 
-module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/pinterest.js
+++ b/src/providers/pinterest.js
@@ -2,15 +2,16 @@
 
 const { $jsonld } = require('@metascraper/helpers')
 
-const getProfileUrl = input => `https://www.pinterest.com/${input}/`
+const getAvatarUrl = input => `https://www.pinterest.com/${input}/`
 
-const getAvatarUrl = $jsonld('mainEntity.image.contentUrl')
+const getAvatar = $jsonld('mainEntity.image.contentUrl')
 
 module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'pinterest',
-    url: getProfileUrl,
-    getter: getAvatarUrl
+    url: getAvatarUrl,
+    getter: getAvatar
   })
 
 module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/psnprofiles.js
+++ b/src/providers/psnprofiles.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const getAvatarUrl = ({ $, getOgImage, NOT_FOUND }) => {
+const getAvatar = ({ $, getOgImage, NOT_FOUND }) => {
   const ogImage = getOgImage($)
   return ogImage === undefined ? NOT_FOUND : ogImage
 }
@@ -9,7 +9,7 @@ module.exports = ({ createHtmlProvider, getOgImage, NOT_FOUND }) =>
   createHtmlProvider({
     name: 'psnprofiles',
     url: input => `https://psnprofiles.com/${input}`,
-    getter: $ => getAvatarUrl({ $, getOgImage, NOT_FOUND })
+    getter: $ => getAvatar({ $, getOgImage, NOT_FOUND })
   })
 
-module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/stackoverflow.js
+++ b/src/providers/stackoverflow.js
@@ -8,19 +8,19 @@ const normalizeUserId = input =>
     .replace(/^users\//, '')
     .split('/')[0]
 
-const getProfileUrl = input =>
+const getAvatarUrl = input =>
   `https://stackoverflow.com/users/${normalizeUserId(input)}`
 
-const getAvatarUrl = $ =>
+const getAvatar = $ =>
   $(`${AVATAR_SELECTOR}[width="128"]`).attr('src') ||
   $(AVATAR_SELECTOR).first().attr('src')
 
 module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'stackoverflow',
-    url: getProfileUrl,
-    getter: getAvatarUrl
+    url: getAvatarUrl,
+    getter: getAvatar
   })
 
-module.exports.getProfileUrl = getProfileUrl
 module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/substack.js
+++ b/src/providers/substack.js
@@ -23,14 +23,13 @@ const getPictureAvatar = $ => {
   return getBestSrcsetUrl(srcset) || pictureImg.attr('src')
 }
 
-const getAvatarUrl = $ =>
-  $jsonld('publisher.logo.url')($) || getPictureAvatar($)
+const getAvatar = $ => $jsonld('publisher.logo.url')($) || getPictureAvatar($)
 
 module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'substack',
     url: input => `https://${input}.substack.com`,
-    getter: getAvatarUrl
+    getter: getAvatar
   })
 
-module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/thingiverse.js
+++ b/src/providers/thingiverse.js
@@ -1,16 +1,16 @@
 'use strict'
 
-const getProfileUrl = input => `https://www.thingiverse.com/${input}`
+const getAvatarUrl = input => `https://www.thingiverse.com/${input}`
 
-const getAvatarUrl = ({ getOgImage, $ }) =>
+const getAvatar = ({ getOgImage, $ }) =>
   new URL(getOgImage($)).searchParams.get('url')
 
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'thingiverse',
-    url: getProfileUrl,
-    getter: $ => getAvatarUrl({ getOgImage, $ })
+    url: getAvatarUrl,
+    getter: $ => getAvatar({ getOgImage, $ })
   })
 
-module.exports.getAvatarUrl = getProfileUrl
-module.exports.getAvatarUrlFromMarkup = getAvatarUrl
+module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/tiktok.js
+++ b/src/providers/tiktok.js
@@ -2,7 +2,7 @@
 
 const { get } = require('lodash')
 
-const getAvatarUrl = $ => {
+const getAvatar = $ => {
   const text = $('#__UNIVERSAL_DATA_FOR_REHYDRATION__').contents().text()
   if (!text) return
   return get(JSON.parse(text), [
@@ -18,7 +18,7 @@ module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'tiktok',
     url: input => `https://www.tiktok.com/@${input}`,
-    getter: getAvatarUrl
+    getter: getAvatar
   })
 
-module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/x.js
+++ b/src/providers/x.js
@@ -12,14 +12,14 @@ const toHighResolution = url => {
   return url
 }
 
-const getProfileImage = ($, getOgImage) =>
+const getAvatar = ($, getOgImage) =>
   toHighResolution($jsonld('mainEntity.image.contentUrl')($) || getOgImage($))
 
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'x',
     url: input => `https://x.com/${input}`,
-    getter: $ => getProfileImage($, getOgImage)
+    getter: $ => getAvatar($, getOgImage)
   })
 
-module.exports.getProfileImage = getProfileImage
+module.exports.getAvatar = getAvatar

--- a/test/unit/providers/buymeacoffee.js
+++ b/test/unit/providers/buymeacoffee.js
@@ -3,7 +3,7 @@
 const test = require('ava')
 const cheerio = require('cheerio')
 
-const { getAvatarUrl } = require('../../../src/providers/buymeacoffee')
+const { getAvatar } = require('../../../src/providers/buymeacoffee')
 
 const avatarUrl =
   'https://cdn.buymeacoffee.com/uploads/profile_pictures/2019/04/abf02d8c433f9b9b36272b48e66ceba8.jpg'
@@ -17,7 +17,7 @@ test('buymeacoffee provider exposes expected URL', t => {
   t.is(provider.url('kikobeats'), 'https://buymeacoffee.com/kikobeats')
 })
 
-test('.getAvatarUrl extracts creator avatar from data-page payload', t => {
+test('.getAvatar extracts creator avatar from data-page payload', t => {
   const html = `
     <html>
       <body>
@@ -27,10 +27,10 @@ test('.getAvatarUrl extracts creator avatar from data-page payload', t => {
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), avatarUrl)
+  t.is(getAvatar($), avatarUrl)
 })
 
-test('.getAvatarUrl falls back to regex extraction when data-page is not valid JSON', t => {
+test('.getAvatar falls back to regex extraction when data-page is not valid JSON', t => {
   const escapedAvatarUrl = avatarUrl.replace(/\//g, '\\/')
   const html = `
     <html>
@@ -41,10 +41,10 @@ test('.getAvatarUrl falls back to regex extraction when data-page is not valid J
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), avatarUrl)
+  t.is(getAvatar($), avatarUrl)
 })
 
-test('.getAvatarUrl returns undefined when data-page payload is missing', t => {
+test('.getAvatar returns undefined when data-page payload is missing', t => {
   const $ = cheerio.load('<html><body></body></html>')
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })

--- a/test/unit/providers/dockerhub.js
+++ b/test/unit/providers/dockerhub.js
@@ -2,14 +2,14 @@
 
 const test = require('ava')
 
-const { getUserUrl } = require('../../../src/providers/dockerhub')
+const { getAvatarUrl } = require('../../../src/providers/dockerhub')
 
 const createDockerHub = got =>
   require('../../../src/providers/dockerhub')({ got })
 
-test('dockerhub builds encoded user API URL', t => {
+test('.getAvatarUrl builds encoded user API URL', t => {
   t.is(
-    getUserUrl('linux/server'),
+    getAvatarUrl('linux/server'),
     'https://hub.docker.com/v2/users/linux%2Fserver/'
   )
 })

--- a/test/unit/providers/flickr.js
+++ b/test/unit/providers/flickr.js
@@ -3,10 +3,7 @@
 const cheerio = require('cheerio')
 const test = require('ava')
 
-const {
-  getAvatarUrl,
-  getAvatarFromMarkup
-} = require('../../../src/providers/flickr')
+const { getAvatarUrl, getAvatar } = require('../../../src/providers/flickr')
 
 test('.getAvatarUrl supports default username input', t => {
   t.is(
@@ -23,10 +20,7 @@ test('.getAvatarUrl supports explicit user username input', t => {
 })
 
 test('.getAvatarUrl supports explicit user numeric input', t => {
-  t.is(
-    getAvatarUrl('user:94867603'),
-    'https://www.flickr.com/photos/94867603/'
-  )
+  t.is(getAvatarUrl('user:94867603'), 'https://www.flickr.com/photos/94867603/')
 })
 
 test('.getAvatarUrl supports group path', t => {
@@ -57,7 +51,7 @@ test('.getter extracts buddy icon URL from profile style markup', t => {
   `)
 
   t.is(
-    getAvatarFromMarkup($),
+    getAvatar($),
     '//live.staticflickr.com/544/buddyicons/94867603@N03_r.jpg?1483529005#94867603@N03'
   )
 })
@@ -71,7 +65,7 @@ test('.getter extracts buddy icon URL from group img markup', t => {
   `)
 
   t.is(
-    getAvatarFromMarkup($),
+    getAvatar($),
     'https://farm8.staticflickr.com/7304/buddyicons/80641914@N00_r.jpg?1422640699'
   )
 })
@@ -84,7 +78,7 @@ test('.getter extracts escaped buddy icon URL from script markup', t => {
   `)
 
   t.is(
-    getAvatarFromMarkup($),
+    getAvatar($),
     'https://live.staticflickr.com/544/buddyicons/94867603@N03_r.jpg?1483529005#94867603@N03'
   )
 })

--- a/test/unit/providers/ko-fi.js
+++ b/test/unit/providers/ko-fi.js
@@ -3,7 +3,7 @@
 const test = require('ava')
 const cheerio = require('cheerio')
 
-const { getAvatarUrl } = require('../../../src/providers/ko-fi')
+const { getAvatar } = require('../../../src/providers/ko-fi')
 
 test('ko-fi provider exposes expected URL', t => {
   const createHtmlProvider = opts => opts
@@ -14,7 +14,7 @@ test('ko-fi provider exposes expected URL', t => {
   t.is(provider.url('kikobeats'), 'https://ko-fi.com/kikobeats')
 })
 
-test('.getAvatarUrl extracts profile picture src', t => {
+test('.getAvatar extracts profile picture src', t => {
   const html = `
     <html>
       <body>
@@ -24,12 +24,12 @@ test('.getAvatarUrl extracts profile picture src', t => {
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), 'https://storage.ko-fi.com/cdn/useruploads/avatar.png')
+  t.is(getAvatar($), 'https://storage.ko-fi.com/cdn/useruploads/avatar.png')
 })
 
-test('.getAvatarUrl returns undefined when profile picture is missing', t => {
+test('.getAvatar returns undefined when profile picture is missing', t => {
   const html = '<html><body></body></html>'
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })

--- a/test/unit/providers/mastodon.js
+++ b/test/unit/providers/mastodon.js
@@ -3,30 +3,30 @@
 const test = require('ava')
 const sinon = require('sinon')
 
-const { parseMastodonInput } = require('../../../src/providers/mastodon')
+const { parseInput } = require('../../../src/providers/mastodon')
 
 test('parses @user@server format', t => {
-  t.deepEqual(parseMastodonInput('@kiko@indieweb.social'), {
+  t.deepEqual(parseInput('@kiko@indieweb.social'), {
     username: 'kiko',
     server: 'indieweb.social'
   })
 })
 
 test('parses user@server format without leading @', t => {
-  t.deepEqual(parseMastodonInput('kiko@indieweb.social'), {
+  t.deepEqual(parseInput('kiko@indieweb.social'), {
     username: 'kiko',
     server: 'indieweb.social'
   })
 })
 
 test('returns undefined for bare username without server', t => {
-  t.is(parseMastodonInput('kikobeats'), undefined)
+  t.is(parseInput('kikobeats'), undefined)
 })
 
 test('returns undefined for malformed handles', t => {
-  t.is(parseMastodonInput('@@localhost:8080'), undefined)
-  t.is(parseMastodonInput('@user@'), undefined)
-  t.is(parseMastodonInput('@user@a@127.0.0.1'), undefined)
+  t.is(parseInput('@@localhost:8080'), undefined)
+  t.is(parseInput('@user@'), undefined)
+  t.is(parseInput('@user@a@127.0.0.1'), undefined)
 })
 
 const createMastodon = (got, isReservedIp) =>

--- a/test/unit/providers/onlyfans.js
+++ b/test/unit/providers/onlyfans.js
@@ -19,9 +19,9 @@ test('onlyfans provider exposes expected URL and html opts', t => {
   })
 })
 
-const { getAvatarUrl } = require('../../../src/providers/onlyfans')
+const { getAvatar } = require('../../../src/providers/onlyfans')
 
-test('.getAvatarUrl parses JSON-LD avatar URL', t => {
+test('.getAvatar parses JSON-LD avatar URL', t => {
   const html = `
     <html>
       <head>
@@ -32,10 +32,10 @@ test('.getAvatarUrl parses JSON-LD avatar URL', t => {
     </html>
   `
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), 'https://cdn.example.com/of-avatar.jpg')
+  t.is(getAvatar($), 'https://cdn.example.com/of-avatar.jpg')
 })
 
-test('.getAvatarUrl returns undefined when JSON-LD script is missing', t => {
+test('.getAvatar returns undefined when JSON-LD script is missing', t => {
   const $ = cheerio.load('<html><head></head></html>')
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })

--- a/test/unit/providers/pinterest.js
+++ b/test/unit/providers/pinterest.js
@@ -3,12 +3,12 @@
 const test = require('ava')
 const cheerio = require('cheerio')
 
-const { getAvatarUrl } = require('../../../src/providers/pinterest')
+const { getAvatar } = require('../../../src/providers/pinterest')
 
 const AVATAR_URL =
   'https://i.pinimg.com/280x280_RS/9a/44/f6/9a44f6b6bffba5e3bc1de97f92d346c1.jpg'
 
-test('.getAvatarUrl returns avatar URL from JSON-LD mainEntity.image.contentUrl', t => {
+test('.getAvatar returns avatar URL from JSON-LD mainEntity.image.contentUrl', t => {
   const $ = cheerio.load(
     `<html><head>
       <script type="application/ld+json">
@@ -17,10 +17,10 @@ test('.getAvatarUrl returns avatar URL from JSON-LD mainEntity.image.contentUrl'
     </head><body></body></html>`
   )
 
-  t.is(getAvatarUrl($), AVATAR_URL)
+  t.is(getAvatar($), AVATAR_URL)
 })
 
-test('.getAvatarUrl returns undefined when JSON-LD is present but avatar path is missing', t => {
+test('.getAvatar returns undefined when JSON-LD is present but avatar path is missing', t => {
   const $ = cheerio.load(
     `<html><head>
       <script type="application/ld+json">
@@ -29,10 +29,10 @@ test('.getAvatarUrl returns undefined when JSON-LD is present but avatar path is
     </head><body></body></html>`
   )
 
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })
 
-test('.getAvatarUrl returns undefined when Pinterest avatar data is missing', t => {
+test('.getAvatar returns undefined when Pinterest avatar data is missing', t => {
   const $ = cheerio.load('<html><head></head><body></body></html>')
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })

--- a/test/unit/providers/psnprofiles.js
+++ b/test/unit/providers/psnprofiles.js
@@ -4,13 +4,13 @@ const test = require('ava')
 const cheerio = require('cheerio')
 
 const { NOT_FOUND } = require('../../../src/util/html-provider')
-const { getAvatarUrl } = require('../../../src/providers/psnprofiles')
+const { getAvatar } = require('../../../src/providers/psnprofiles')
 
-test('getAvatarUrl returns NOT_FOUND when og:image is missing', t => {
+test('getAvatar returns NOT_FOUND when og:image is missing', t => {
   const $ = cheerio.load('<html><title>PSNProfiles</title></html>')
 
   t.is(
-    getAvatarUrl({
+    getAvatar({
       $,
       getOgImage: $ => $('meta[property="og:image"]').attr('content'),
       NOT_FOUND
@@ -19,13 +19,13 @@ test('getAvatarUrl returns NOT_FOUND when og:image is missing', t => {
   )
 })
 
-test('getAvatarUrl returns og:image when present', t => {
+test('getAvatar returns og:image when present', t => {
   const $ = cheerio.load(
     '<meta property="og:image" content="https://i.psnprofiles.com/avatar.png" />'
   )
 
   t.is(
-    getAvatarUrl({
+    getAvatar({
       $,
       getOgImage: $ => $('meta[property="og:image"]').attr('content'),
       NOT_FOUND

--- a/test/unit/providers/stackoverflow.js
+++ b/test/unit/providers/stackoverflow.js
@@ -3,27 +3,27 @@
 const cheerio = require('cheerio')
 const test = require('ava')
 
-const { getProfileUrl, getAvatarUrl } = require('../../../src/providers/stackoverflow')
+const {
+  getAvatarUrl,
+  getAvatar
+} = require('../../../src/providers/stackoverflow')
 
-test('.getProfileUrl builds users URL from ID', t => {
-  t.is(getProfileUrl('576911'), 'https://stackoverflow.com/users/576911')
+test('.getAvatarUrl builds users URL from ID', t => {
+  t.is(getAvatarUrl('576911'), 'https://stackoverflow.com/users/576911')
 })
 
-test('.getProfileUrl supports input prefixed with users/', t => {
+test('.getAvatarUrl supports input prefixed with users/', t => {
+  t.is(getAvatarUrl('users/576911'), 'https://stackoverflow.com/users/576911')
+})
+
+test('.getAvatarUrl keeps only user ID when a slug is present', t => {
   t.is(
-    getProfileUrl('users/576911'),
+    getAvatarUrl('/users/576911/example-slug'),
     'https://stackoverflow.com/users/576911'
   )
 })
 
-test('.getProfileUrl keeps only user ID when a slug is present', t => {
-  t.is(
-    getProfileUrl('/users/576911/example-slug'),
-    'https://stackoverflow.com/users/576911'
-  )
-})
-
-test('.getAvatarUrl resolves expected avatar from inline stackoverflow markup', t => {
+test('.getAvatar resolves expected avatar from inline stackoverflow markup', t => {
   const html = `
     <html>
       <body>
@@ -39,7 +39,7 @@ test('.getAvatarUrl resolves expected avatar from inline stackoverflow markup', 
   const $ = cheerio.load(html)
 
   t.is(
-    getAvatarUrl($),
+    getAvatar($),
     'https://www.gravatar.com/avatar/27c58ba8661585b00b571efab36af60f?s=256&d=identicon&r=PG'
   )
 })

--- a/test/unit/providers/substack.js
+++ b/test/unit/providers/substack.js
@@ -5,9 +5,9 @@ const fs = require('fs')
 const path = require('path')
 const test = require('ava')
 
-const { getAvatarUrl } = require('../../../src/providers/substack')
+const { getAvatar } = require('../../../src/providers/substack')
 
-test('.getAvatarUrl returns publisher logo from jsonld', t => {
+test('.getAvatar returns publisher logo from jsonld', t => {
   const html = `
     <html>
       <head>
@@ -20,10 +20,10 @@ test('.getAvatarUrl returns publisher logo from jsonld', t => {
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), 'https://cdn.example.com/logo.jpg')
+  t.is(getAvatar($), 'https://cdn.example.com/logo.jpg')
 })
 
-test('.getAvatarUrl falls back to highest resolution picture srcset when jsonld logo is missing', t => {
+test('.getAvatar falls back to highest resolution picture srcset when jsonld logo is missing', t => {
   const html = `
     <html>
       <body>
@@ -42,10 +42,10 @@ test('.getAvatarUrl falls back to highest resolution picture srcset when jsonld 
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), 'https://substackcdn.com/image/fetch/w_264/avatar.png')
+  t.is(getAvatar($), 'https://substackcdn.com/image/fetch/w_264/avatar.png')
 })
 
-test('.getAvatarUrl falls back to picture img src when srcset is missing', t => {
+test('.getAvatar falls back to picture img src when srcset is missing', t => {
   const html = `
     <html>
       <body>
@@ -57,10 +57,10 @@ test('.getAvatarUrl falls back to picture img src when srcset is missing', t => 
   `
 
   const $ = cheerio.load(html)
-  t.is(getAvatarUrl($), 'https://substackcdn.com/image/fetch/w_88/avatar.png')
+  t.is(getAvatar($), 'https://substackcdn.com/image/fetch/w_88/avatar.png')
 })
 
-test('.getAvatarUrl parses srcset URLs containing commas', t => {
+test('.getAvatar parses srcset URLs containing commas', t => {
   const html = `
     <html>
       <body>
@@ -76,17 +76,20 @@ test('.getAvatarUrl parses srcset URLs containing commas', t => {
 
   const $ = cheerio.load(html)
   t.is(
-    getAvatarUrl($),
+    getAvatar($),
     'https://substackcdn.com/image/fetch/$s_!b-El!,w_264,h_264,c_fill,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fimg.png'
   )
 })
 
-test('.getAvatarUrl resolves expected avatar from real substack datacenter fixture', t => {
-  const html = fs.readFileSync(path.join(__dirname, 'substack-datacenter.html'), 'utf8')
+test('.getAvatar resolves expected avatar from real substack datacenter fixture', t => {
+  const html = fs.readFileSync(
+    path.join(__dirname, 'substack-datacenter.html'),
+    'utf8'
+  )
   const $ = cheerio.load(html)
 
   t.is(
-    getAvatarUrl($),
+    getAvatar($),
     'https://substackcdn.com/image/fetch/$s_!b-El!,w_264,h_264,c_fill,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F65139ad0-319a-42ca-9a37-c024fae1c727_1024x1024.png'
   )
 })

--- a/test/unit/providers/thingiverse.js
+++ b/test/unit/providers/thingiverse.js
@@ -6,7 +6,7 @@ const test = require('ava')
 const getOgImage = require('../../../src/util/get-og-image')
 const {
   getAvatarUrl,
-  getAvatarUrlFromMarkup
+  getAvatar
 } = require('../../../src/providers/thingiverse')
 
 test('.getAvatarUrl returns Thingiverse profile URL', t => {
@@ -39,12 +39,12 @@ test('getter throws when og:image is missing', t => {
   t.is(error?.name, 'TypeError')
 })
 
-test('.getAvatarUrlFromMarkup returns null when url query parameter is missing', t => {
+test('.getAvatar returns null when url query parameter is missing', t => {
   const $ = cheerio.load(
     '<html><head>' +
       '<meta property="og:image" content="https://cdn.thingiverse.com/avatar.jpg"/>' +
       '</head></html>'
   )
 
-  t.is(getAvatarUrlFromMarkup({ getOgImage, $ }), null)
+  t.is(getAvatar({ getOgImage, $ }), null)
 })

--- a/test/unit/providers/tiktok.js
+++ b/test/unit/providers/tiktok.js
@@ -5,19 +5,19 @@ const path = require('path')
 const ava = require('ava')
 const fs = require('fs')
 
-const { getAvatarUrl } = require('../../../src/providers/tiktok')
+const { getAvatar } = require('../../../src/providers/tiktok')
 
-ava('.getAvatarUrl returns the correct avatar URL', t => {
+ava('.getAvatar returns the correct avatar URL', t => {
   const html = fs.readFileSync(path.join(__dirname, 'tiktok.html'), 'utf8')
   const $ = cheerio.load(html)
-  const avatarUrl = getAvatarUrl($)
+  const avatarUrl = getAvatar($)
   t.is(
     avatarUrl,
     'https://p16-pu-sign-no.tiktokcdn-eu.com/tos-no1a-avt-0068c001-no/340072a4400ed43a83d255f346b879aa~tplv-tiktokx-cropcenter:1080:1080.jpeg?dr=10399&refresh_token=02720a18&x-expires=1765267200&x-signature=tc69d0XimWmLbqH%2F2vOg941kpgE%3D&t=4d5b0474&ps=13740610&shp=a5d48078&shcp=81f88b70&idc=no1a'
   )
 })
 
-ava('.getAvatarUrl returns undefined when universal payload is missing', t => {
+ava('.getAvatar returns undefined when universal payload is missing', t => {
   const $ = cheerio.load('<html><head></head><body></body></html>')
-  t.is(getAvatarUrl($), undefined)
+  t.is(getAvatar($), undefined)
 })

--- a/test/unit/providers/x.js
+++ b/test/unit/providers/x.js
@@ -5,30 +5,30 @@ const path = require('path')
 const test = require('ava')
 const fs = require('fs')
 
-const { getProfileImage } = require('../../../src/providers/x')
+const { getAvatar } = require('../../../src/providers/x')
 const getOgImage = require('../../../src/util/get-og-image')
 
-test('.getProfileImage from JSON-LD when og:image is fallback', t => {
+test('.getAvatar from JSON-LD when og:image is fallback', t => {
   const html = fs.readFileSync(path.join(__dirname, 'x-jsonld.html'), 'utf8')
   const $ = cheerio.load(html)
-  const avatarUrl = getProfileImage($, getOgImage)
+  const avatarUrl = getAvatar($, getOgImage)
   t.is(
     avatarUrl,
     'https://pbs.twimg.com/profile_images/1846292082501054464/oKUC44PF_400x400.jpg'
   )
 })
 
-test('.getProfileImage from og:image and transforms to high resolution', t => {
+test('.getAvatar from og:image and transforms to high resolution', t => {
   const html = fs.readFileSync(path.join(__dirname, 'x-og.html'), 'utf8')
   const $ = cheerio.load(html)
-  const avatarUrl = getProfileImage($, getOgImage)
+  const avatarUrl = getAvatar($, getOgImage)
   t.is(
     avatarUrl,
     'https://pbs.twimg.com/profile_images/1846292082501054464/oKUC44PF_400x400.jpg'
   )
 })
 
-test('.getProfileImage transforms `_normal` image URLs to high resolution', t => {
+test('.getAvatar transforms `_normal` image URLs to high resolution', t => {
   const html = `
     <html>
       <head>
@@ -37,11 +37,11 @@ test('.getProfileImage transforms `_normal` image URLs to high resolution', t =>
     </html>
   `
   const $ = cheerio.load(html)
-  const avatarUrl = getProfileImage($, getOgImage)
+  const avatarUrl = getAvatar($, getOgImage)
   t.is(avatarUrl, 'https://pbs.twimg.com/profile_images/123/avatar_400x400.jpg')
 })
 
-test('.getProfileImage keeps non-twitter image URLs unchanged', t => {
+test('.getAvatar keeps non-twitter image URLs unchanged', t => {
   const html = `
     <html>
       <head>
@@ -50,7 +50,7 @@ test('.getProfileImage keeps non-twitter image URLs unchanged', t => {
     </html>
   `
   const $ = cheerio.load(html)
-  const avatarUrl = getProfileImage($, getOgImage)
+  const avatarUrl = getAvatar($, getOgImage)
   t.is(avatarUrl, 'https://example.com/avatar.jpg')
 })
 
@@ -91,7 +91,7 @@ test('.provider returns undefined on 404 without proxying', async t => {
   t.false(headerCalled)
 })
 
-test('.getProfileImage returns undefined when profile is missing', t => {
+test('.getAvatar returns undefined when profile is missing', t => {
   const html = `
     <html>
       <head>
@@ -101,6 +101,6 @@ test('.getProfileImage returns undefined when profile is missing', t => {
     </html>
   `
   const $ = cheerio.load(html)
-  const avatarUrl = getProfileImage($, getOgImage)
+  const avatarUrl = getAvatar($, getOgImage)
   t.is(avatarUrl, undefined)
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily a cross-provider rename/refactor, but it changes exported helper names (and in a couple cases which function is exported), which can break any external/internal code importing the old symbols.
> 
> **Overview**
> Standardizes provider helper naming by renaming HTML extraction helpers to `getAvatar` and URL builders to `getAvatarUrl` across multiple providers (e.g., BuyMeACoffee, Ko-fi, OnlyFans, TikTok, Substack, Flickr, X, StackOverflow, Pinterest, PSNProfiles, Thingiverse, DockerHub, GitHub), and updates unit tests accordingly.
> 
> Also renames Mastodon’s `parseMastodonInput` to `parseInput` and GitHub’s username avatar helper to `getAvatarUrl`, adjusting corresponding exports so providers expose consistent helper APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c061b1313d968d971648c89f0c1056eeda9d338f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->