### PR TITLE
chore(dockerhub): respect AVATAR_SIZE

### DIFF
--- a/src/providers/dockerhub.js
+++ b/src/providers/dockerhub.js
@@ -3,8 +3,17 @@
 const API_URL = 'https://hub.docker.com/v2/users'
 
 const getAvatarUrl = input => `${API_URL}/${encodeURIComponent(input)}/`
+const getMaxResGravatarUrl = ({ constants, input }) => {
+  const url = new URL(input)
 
-module.exports = ({ got }) =>
+  // `d=404` makes missing avatars fail instead of falling back to placeholders.
+  url.searchParams.set('s', String(constants.AVATAR_SIZE))
+  url.searchParams.set('d', '404')
+
+  return url.toString()
+}
+
+module.exports = ({ constants, got }) =>
   async function dockerhub (input) {
     const { body, statusCode } = await got(getAvatarUrl(input), {
       responseType: 'json',
@@ -13,7 +22,10 @@ module.exports = ({ got }) =>
 
     if (statusCode >= 400) return
 
-    return body?.gravatar_url || undefined
+    if (!body?.gravatar_url) return undefined
+
+    return getMaxResGravatarUrl({ constants, input: body.gravatar_url })
   }
 
 module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getMaxResGravatarUrl = getMaxResGravatarUrl

--- a/test/unit/providers/dockerhub.js
+++ b/test/unit/providers/dockerhub.js
@@ -3,9 +3,10 @@
 const test = require('ava')
 
 const { getAvatarUrl } = require('../../../src/providers/dockerhub')
+const constants = require('../../../src/constant')
 
 const createDockerHub = got =>
-  require('../../../src/providers/dockerhub')({ got })
+  require('../../../src/providers/dockerhub')({ constants, got })
 
 test('.getAvatarUrl builds encoded user API URL', t => {
   t.is(
@@ -33,7 +34,7 @@ test('dockerhub resolves gravatar_url from user profile', async t => {
 
   t.is(
     result,
-    'https://www.gravatar.com/avatar/56b6e15d486f6407690a6cb56e3fa68e?s=80&r=g&d=mm'
+    'https://www.gravatar.com/avatar/56b6e15d486f6407690a6cb56e3fa68e?s=400&r=g&d=404'
   )
 })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change limited to DockerHub avatar URL normalization and corresponding unit test updates.
> 
> **Overview**
> DockerHub avatar resolution now rewrites returned `gravatar_url` values to enforce the configured `AVATAR_SIZE` and forces `d=404` so missing Gravatar images fail instead of falling back to placeholders.
> 
> Updates the DockerHub provider factory to accept `constants` and adds/exports `getMaxResGravatarUrl`, with unit tests adjusted to inject constants and assert the new normalized Gravatar URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ec68ecabcba91cd2c86b37846a155f033e3b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->