### PR TITLE
chore(npm): get avatar from github/gitlab

### DIFF
--- a/src/providers/npm.js
+++ b/src/providers/npm.js
@@ -1,24 +1,38 @@
 'use strict'
 
-const NPM_URL = 'https://www.npmjs.com'
+const { getAvatarUrl: getGitHubAvatarUrl } = require('./github')
+const stringify = require('../util/stringify')
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org'
 
 const stripAtPrefix = input => input.replace(/^@/, '')
 
-const getAvatarUrl = input => `${NPM_URL}/~${stripAtPrefix(input)}`
+const GITHUB_RE = /github\.com[/:]([^/]+)/
 
-const getAvatar = $ => {
-  const src = $('a[aria-label="Your profile picture"] img').attr('src')
-  if (!src) return
-
-  return src.startsWith('/') ? `${NPM_URL}${src}` : src
+const getGitHubUsername = objects => {
+  for (const { package: pkg } of objects) {
+    const repo = pkg?.links?.repository
+    if (!repo) continue
+    const match = GITHUB_RE.exec(repo)
+    if (match) return match[1]
+  }
 }
 
-module.exports = ({ createHtmlProvider }) =>
-  createHtmlProvider({
-    name: 'npm',
-    url: getAvatarUrl,
-    getter: getAvatar
-  })
+module.exports = ({ constants, got }) =>
+  async function npm (input) {
+    const username = stripAtPrefix(input)
+    const url = `${NPM_REGISTRY_URL}/-/v1/search?${stringify({
+      text: `maintainer:${username}`,
+      size: 5
+    })}`
 
-module.exports.getAvatarUrl = getAvatarUrl
-module.exports.getAvatar = getAvatar
+    const { body } = await got(url, { responseType: 'json' })
+    const objects = (body?.objects ?? []).filter(
+      o => o.package?.publisher?.username === username
+    )
+
+    const githubUsername = getGitHubUsername(objects)
+    if (!githubUsername) return
+
+    return getGitHubAvatarUrl({ constants, input: githubUsername })
+  }

--- a/src/providers/npm.js
+++ b/src/providers/npm.js
@@ -4,18 +4,38 @@ const { getAvatarUrl: getGitHubAvatarUrl } = require('./github')
 const stringify = require('../util/stringify')
 
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org'
+const GITLAB_API_URL = 'https://gitlab.com/api/v4'
 
 const stripAtPrefix = input => input.replace(/^@/, '')
 
 const GITHUB_RE = /github\.com[/:]([^/]+)/
+const GITLAB_RE = /gitlab\.com[/:]([^/]+)/
 
-const getGitHubUsername = objects => {
+const getRepoUsername = objects => {
+  let gitlabFallback
+
   for (const { package: pkg } of objects) {
     const repo = pkg?.links?.repository
     if (!repo) continue
-    const match = GITHUB_RE.exec(repo)
-    if (match) return match[1]
+
+    const githubMatch = GITHUB_RE.exec(repo)
+    if (githubMatch) return { platform: 'github', username: githubMatch[1] }
+
+    if (!gitlabFallback) {
+      const gitlabMatch = GITLAB_RE.exec(repo)
+      if (gitlabMatch) { gitlabFallback = { platform: 'gitlab', username: gitlabMatch[1] } }
+    }
   }
+
+  return gitlabFallback
+}
+
+const getGitLabAvatarUrl = async ({ got, username }) => {
+  const { body } = await got(
+    `${GITLAB_API_URL}/users?username=${encodeURIComponent(username)}`,
+    { responseType: 'json' }
+  )
+  return body?.[0]?.avatar_url
 }
 
 module.exports = ({ constants, got }) =>
@@ -31,8 +51,12 @@ module.exports = ({ constants, got }) =>
       o => o.package?.publisher?.username === username
     )
 
-    const githubUsername = getGitHubUsername(objects)
-    if (!githubUsername) return
+    const match = getRepoUsername(objects)
+    if (!match) return
 
-    return getGitHubAvatarUrl({ constants, input: githubUsername })
+    if (match.platform === 'github') {
+      return getGitHubAvatarUrl({ constants, input: match.username })
+    }
+
+    return getGitLabAvatarUrl({ got, username: match.username })
   }

--- a/test/unit/providers/npm.js
+++ b/test/unit/providers/npm.js
@@ -1,44 +1,94 @@
 'use strict'
 
 const test = require('ava')
-const cheerio = require('cheerio')
 
-const { getAvatarUrl, getAvatar } = require('../../../src/providers/npm')
+const createNpmProvider = require('../../../src/providers/npm')
 
-test('.getAvatarUrl returns npm profile URL', t => {
-  t.is(getAvatarUrl('kikobeats'), 'https://www.npmjs.com/~kikobeats')
+const createMockGot = response => async () => ({ body: response })
+
+test('returns github avatar URL from npm registry', async t => {
+  const got = createMockGot({
+    objects: [
+      {
+        package: {
+          publisher: { username: 'mafintosh' },
+          links: { repository: 'git://github.com/mafintosh/pump.git' }
+        }
+      }
+    ]
+  })
+
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('mafintosh')
+
+  t.is(result, 'https://github.com/mafintosh.png?size=400')
 })
 
-test('.getAvatarUrl strips @ prefix from input', t => {
-  t.is(getAvatarUrl('@kikobeats'), 'https://www.npmjs.com/~kikobeats')
+test('strips @ prefix from input', async t => {
+  const got = createMockGot({
+    objects: [
+      {
+        package: {
+          publisher: { username: 'kikobeats' },
+          links: { repository: 'https://github.com/kikobeats/emojis-list' }
+        }
+      }
+    ]
+  })
+
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('@kikobeats')
+
+  t.is(result, 'https://github.com/kikobeats.png?size=400')
 })
 
-test('.getAvatar extracts npm profile avatar', t => {
-  const html = `
-    <main id="main">
-      <a href="http://en.gravatar.com/emails/" aria-label="Your profile picture">
-        <img src="/npm-avatar/avatar-token" alt="" />
-      </a>
-      <img src="https://static-production.npmjs.com/package.svg" />
-    </main>
-  `
-  const $ = cheerio.load(html)
+test('filters packages by publisher username', async t => {
+  const got = createMockGot({
+    objects: [
+      {
+        package: {
+          publisher: { username: 'other-user' },
+          links: { repository: 'https://github.com/other-user/pkg.git' }
+        }
+      },
+      {
+        package: {
+          publisher: { username: 'mafintosh' },
+          links: { repository: 'https://github.com/mafintosh/pump.git' }
+        }
+      }
+    ]
+  })
 
-  t.is(getAvatar($), 'https://www.npmjs.com/npm-avatar/avatar-token')
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('mafintosh')
+
+  t.is(result, 'https://github.com/mafintosh.png?size=400')
 })
 
-test('.getAvatar returns absolute profile avatar unchanged', t => {
-  const $ = cheerio.load(`
-    <a aria-label="Your profile picture">
-      <img src="https://static-production.npmjs.com/avatar.png" />
-    </a>
-  `)
+test('returns undefined when no github repository found', async t => {
+  const got = createMockGot({
+    objects: [
+      {
+        package: {
+          publisher: { username: 'noghuser' },
+          links: { npm: 'https://www.npmjs.com/package/foo' }
+        }
+      }
+    ]
+  })
 
-  t.is(getAvatar($), 'https://static-production.npmjs.com/avatar.png')
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('noghuser')
+
+  t.is(result, undefined)
 })
 
-test('.getAvatar returns undefined when avatar is missing', t => {
-  const $ = cheerio.load('<main><img src="/package-icon.svg" /></main>')
+test('returns undefined when no packages found', async t => {
+  const got = createMockGot({ objects: [] })
 
-  t.is(getAvatar($), undefined)
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('nonexistent')
+
+  t.is(result, undefined)
 })

--- a/test/unit/providers/npm.js
+++ b/test/unit/providers/npm.js
@@ -4,19 +4,35 @@ const test = require('ava')
 
 const createNpmProvider = require('../../../src/providers/npm')
 
-const createMockGot = response => async () => ({ body: response })
+const createMockGot = responses => {
+  const calls = []
+  const got = async (url, opts) => {
+    calls.push({ url, opts })
+    for (const [pattern, body] of responses) {
+      if (url.includes(pattern)) return { body }
+    }
+    return { body: null }
+  }
+  got.calls = calls
+  return got
+}
 
 test('returns github avatar URL from npm registry', async t => {
-  const got = createMockGot({
-    objects: [
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
       {
-        package: {
-          publisher: { username: 'mafintosh' },
-          links: { repository: 'git://github.com/mafintosh/pump.git' }
-        }
+        objects: [
+          {
+            package: {
+              publisher: { username: 'mafintosh' },
+              links: { repository: 'git://github.com/mafintosh/pump.git' }
+            }
+          }
+        ]
       }
     ]
-  })
+  ])
 
   const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
   const result = await npm('mafintosh')
@@ -25,16 +41,21 @@ test('returns github avatar URL from npm registry', async t => {
 })
 
 test('strips @ prefix from input', async t => {
-  const got = createMockGot({
-    objects: [
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
       {
-        package: {
-          publisher: { username: 'kikobeats' },
-          links: { repository: 'https://github.com/kikobeats/emojis-list' }
-        }
+        objects: [
+          {
+            package: {
+              publisher: { username: 'kikobeats' },
+              links: { repository: 'https://github.com/kikobeats/emojis-list' }
+            }
+          }
+        ]
       }
     ]
-  })
+  ])
 
   const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
   const result = await npm('@kikobeats')
@@ -43,22 +64,27 @@ test('strips @ prefix from input', async t => {
 })
 
 test('filters packages by publisher username', async t => {
-  const got = createMockGot({
-    objects: [
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
       {
-        package: {
-          publisher: { username: 'other-user' },
-          links: { repository: 'https://github.com/other-user/pkg.git' }
-        }
-      },
-      {
-        package: {
-          publisher: { username: 'mafintosh' },
-          links: { repository: 'https://github.com/mafintosh/pump.git' }
-        }
+        objects: [
+          {
+            package: {
+              publisher: { username: 'other-user' },
+              links: { repository: 'https://github.com/other-user/pkg.git' }
+            }
+          },
+          {
+            package: {
+              publisher: { username: 'mafintosh' },
+              links: { repository: 'https://github.com/mafintosh/pump.git' }
+            }
+          }
+        ]
       }
     ]
-  })
+  ])
 
   const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
   const result = await npm('mafintosh')
@@ -66,17 +92,88 @@ test('filters packages by publisher username', async t => {
   t.is(result, 'https://github.com/mafintosh.png?size=400')
 })
 
-test('returns undefined when no github repository found', async t => {
-  const got = createMockGot({
-    objects: [
+test('returns gitlab avatar URL when repo is on gitlab', async t => {
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
       {
-        package: {
-          publisher: { username: 'noghuser' },
-          links: { npm: 'https://www.npmjs.com/package/foo' }
+        objects: [
+          {
+            package: {
+              publisher: { username: 'dmfay' },
+              links: {
+                repository: 'git+https://gitlab.com/dmfay/massive-js.git'
+              }
+            }
+          }
+        ]
+      }
+    ],
+    [
+      'gitlab.com/api/v4',
+      [
+        {
+          avatar_url:
+            'https://gitlab.com/uploads/-/system/user/avatar/920703/avatar.png'
         }
+      ]
+    ]
+  ])
+
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('dmfay')
+
+  t.is(
+    result,
+    'https://gitlab.com/uploads/-/system/user/avatar/920703/avatar.png'
+  )
+})
+
+test('prefers github over gitlab when both exist', async t => {
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
+      {
+        objects: [
+          {
+            package: {
+              publisher: { username: 'user' },
+              links: { repository: 'https://gitlab.com/user/pkg1.git' }
+            }
+          },
+          {
+            package: {
+              publisher: { username: 'user' },
+              links: { repository: 'https://github.com/user/pkg2.git' }
+            }
+          }
+        ]
       }
     ]
-  })
+  ])
+
+  const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
+  const result = await npm('user')
+
+  t.is(result, 'https://github.com/user.png?size=400')
+})
+
+test('returns undefined when no repository found', async t => {
+  const got = createMockGot([
+    [
+      'registry.npmjs.org',
+      {
+        objects: [
+          {
+            package: {
+              publisher: { username: 'noghuser' },
+              links: { npm: 'https://www.npmjs.com/package/foo' }
+            }
+          }
+        ]
+      }
+    ]
+  ])
 
   const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
   const result = await npm('noghuser')
@@ -85,7 +182,7 @@ test('returns undefined when no github repository found', async t => {
 })
 
 test('returns undefined when no packages found', async t => {
-  const got = createMockGot({ objects: [] })
+  const got = createMockGot([['registry.npmjs.org', { objects: [] }]])
 
   const npm = createNpmProvider({ constants: { AVATAR_SIZE: 400 }, got })
   const result = await npm('nonexistent')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `npm` avatar resolution strategy from HTML scraping to external API lookups (npm registry + GitLab), which can affect results and introduce new failure modes around network/API responses.
> 
> **Overview**
> The `npm` provider is rewritten to stop scraping `npmjs.com` profile HTML and instead query the npm registry for packages maintained by the user, extract the repository host, and resolve an avatar from **GitHub** (via existing `github.getAvatarUrl`) or **GitLab** (via `GET /users?username=`), preferring GitHub when both are present.
> 
> Unit tests are updated accordingly, replacing cheerio-based HTML tests with mocked `got` calls that cover GitHub/GitLab resolution, `@`-prefix normalization, publisher filtering, and undefined returns when no suitable repo/packages are found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62c660adc0887d1a3149fa86c73eaca1d61080b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->