### PR TITLE
fix(x): use intent URL for profile lookup

### DIFF
--- a/src/providers/x.js
+++ b/src/providers/x.js
@@ -18,7 +18,7 @@ const getAvatar = ($, getOgImage) =>
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'x',
-    url: input => `https://x.com/${input}`,
+    url: input => `https://x.com/intent/user?screen_name=${input}`,
     getter: $ => getAvatar($, getOgImage)
   })
 

--- a/src/providers/x.js
+++ b/src/providers/x.js
@@ -18,7 +18,8 @@ const getAvatar = ($, getOgImage) =>
 module.exports = ({ createHtmlProvider, getOgImage }) =>
   createHtmlProvider({
     name: 'x',
-    url: input => `https://x.com/intent/user?screen_name=${input}`,
+    url: input =>
+      `https://x.com/intent/user?screen_name=${encodeURIComponent(input)}`,
     getter: $ => getAvatar($, getOgImage)
   })
 


### PR DESCRIPTION
x.com SSR omits JSON-LD/og:image for underscore-prefixed handles. The intent/user endpoint returns ProfilePage schema for all handles.

Closes #594

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line URL change in the X provider with no auth or data-path impact; behavior depends on X continuing to serve metadata on the intent endpoint.
> 
> **Overview**
> The X HTML provider now fetches profile pages via **`https://x.com/intent/user?screen_name=...`** instead of **`https://x.com/{handle}`**, with **`encodeURIComponent`** on the handle so special characters are safe in the query string.
> 
> Avatar extraction (`getAvatar` / JSON-LD / og:image) is unchanged; the intent endpoint is used because direct profile SSR often omits metadata for underscore-prefixed handles while the intent page still exposes **ProfilePage** schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e16280b9e31df84fa5ff8122191a9a17aac52ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->