### PR TITLE
feat: add wise provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
   - [Twitch](#twitch)
   - [Vimeo](#vimeo)
   - [WhatsApp](#whatsapp)
+  - [Wise](#wise)
   - [X/Twitter](#xtwitter)
   - [Xbox Gamertag](#xbox-gamertag)
   - [YouTube](#youtube)
@@ -961,6 +962,12 @@ Available inputs:
 - `phone`: [unavatar.io/whatsapp/phone:34660021551](https://unavatar.io/whatsapp/phone:34660021551)
 - `channel`: [unavatar.io/whatsapp/channel:0029VaARuQ7KwqSXh9fiMc0m](https://unavatar.io/whatsapp/channel:0029VaARuQ7KwqSXh9fiMc0m)
 - `chat`: [unavatar.io/whatsapp/chat:D2FFycjQXrEIKG8qQjbwZz](https://unavatar.io/whatsapp/chat:D2FFycjQXrEIKG8qQjbwZz)
+
+### Wise
+
+Get any Wise user's profile picture by their Wisetag.
+
+e.g., [unavatar.io/wise/josev2264](https://unavatar.io/wise/josev2264)
 
 ### X/Twitter
 

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -54,6 +54,7 @@ const providersBy = {
     'tumblr',
     'twitch',
     'vimeo',
+    'wise',
     'x',
     'xboxgamertag',
     'youtube'
@@ -119,6 +120,7 @@ module.exports = ctx => {
     twitch: require('./twitch')(ctx),
     vimeo: require('./vimeo')(ctx),
     whatsapp: require('./whatsapp')(ctx),
+    wise: require('./wise')(ctx),
     x: require('./x')(ctx),
     xboxgamertag: require('./xboxgamertag')(ctx),
     youtube: require('./youtube')(ctx)

--- a/src/providers/wise.js
+++ b/src/providers/wise.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { get } = require('lodash')
+
+const getAvatarUrl = input => `https://wise.com/pay/me/${input}`
+
+const getAvatar = $ => {
+  const text = $('#__NEXT_DATA__').contents().text()
+  if (!text) return
+  return get(JSON.parse(text), [
+    'props',
+    'pageProps',
+    'match',
+    'display',
+    'avatar',
+    'value'
+  ])
+}
+
+const factory = ({ createHtmlProvider }) =>
+  createHtmlProvider({
+    name: 'wise',
+    url: getAvatarUrl,
+    getter: getAvatar
+  })
+
+factory.getAvatarUrl = getAvatarUrl
+factory.getAvatar = getAvatar
+
+module.exports = factory

--- a/test/unit/providers/wise.js
+++ b/test/unit/providers/wise.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const test = require('ava')
+const cheerio = require('cheerio')
+
+const { getAvatar, getAvatarUrl } = require('../../../src/providers/wise')
+
+const avatarUrl =
+  'https://tw-avatar.s3.eu-central-1.amazonaws.com/1503ea22-1e33-495c-990c-1bc4fa6cd255'
+
+test('wise builds wisetag profile URL', t => {
+  t.is(getAvatarUrl('josev2264'), 'https://wise.com/pay/me/josev2264')
+})
+
+test('.getAvatar extracts avatar from __NEXT_DATA__ payload', t => {
+  const payload = JSON.stringify({
+    props: {
+      pageProps: {
+        match: { display: { avatar: { type: 'THUMBNAIL', value: avatarUrl } } }
+      }
+    }
+  })
+  const html = `
+    <html>
+      <body>
+        <script type="application/json" id="__NEXT_DATA__">${payload}</script>
+      </body>
+    </html>
+  `
+
+  const $ = cheerio.load(html)
+  t.is(getAvatar($), avatarUrl)
+})
+
+test('.getAvatar returns undefined when __NEXT_DATA__ is missing', t => {
+  const $ = cheerio.load('<html><body></body></html>')
+  t.is(getAvatar($), undefined)
+})


### PR DESCRIPTION
Add a [Wise](https://wise.com) avatar provider, resolving a user's profile picture from their **Wisetag**.

Modeled on the existing PayPal provider: it fetches `https://wise.com/pay/me/<wisetag>` and extracts the avatar from the page's `__NEXT_DATA__` JSON at `props.pageProps.match.display.avatar.value` (an S3 `tw-avatar` URL).

### Usage

```
unavatar.io/wise/josev2264
```

> Note: unlike `paypal.me` / `revolut.me`, a Wisetag always carries a numeric suffix, so the full tag (e.g. `josev2264`) must be supplied — there is no clean-username form.

### Changes

- `src/providers/wise.js` — new HTML provider
- `src/providers/index.js` — register `wise` in the username resolver list and providers map
- `test/unit/providers/wise.js` — unit tests for URL builder + avatar extraction
- `README.md` — TOC entry and provider section

### Verification

- JSON path validated against a live Wisetag page
- New unit tests pass (3/3)
- Provider-consistency suite passes (63/63)
- `standard` lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new provider module plus registry/docs/tests; no changes to auth, billing, or existing provider behavior.
> 
> **Overview**
> Adds **Wise** as a username avatar provider so callers can resolve profile images via `unavatar.io/wise/<wisetag>`.
> 
> The new provider loads `https://wise.com/pay/me/<wisetag>`, reads the Next.js `__NEXT_DATA__` script, and returns the avatar at `props.pageProps.match.display.avatar.value` (same HTML-provider pattern as PayPal/Revolut). **`wise`** is registered in the provider index and documented in the README; unit tests cover URL building, JSON extraction, and the missing-payload case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204b25e7151790accf832aaa61fe25af5a520a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->