### PR TITLE
fix(cli): render url as fallaback

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -154,7 +154,16 @@ module.exports = ({ baseUrl }) => {
     })
     .then(({ buffer, imageUrl }) => {
       console.error()
-      console.error(termImg(buffer, { width: '15%' }))
+      try {
+        console.error(
+          termImg(buffer, {
+            width: '15%',
+            fallback: () => imageUrl
+          })
+        )
+      } catch (_) {
+        console.error(`Avatar preview unavailable. URL: ${imageUrl}`)
+      }
 
       console.error(`
  input: ${apiUrl.toString()}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -44,6 +44,7 @@ const providersBy = {
     'primal',
     'producthunt',
     'psnprofiles',
+    'qq',
     'raycast',
     'reddit',
     'revolut',
@@ -65,13 +66,14 @@ const providersBy = {
     'venmo',
     'vimeo',
     'weibo',
+    'whatsapp',
     'wise',
     'x',
     'xboxgamertag',
     'youtube',
     'zhihu'
   ],
-  domain: ['microlink']
+  domain: ['duckduckgo', 'google', 'microlink']
 }
 
 module.exports = ctx => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI UX and provider ordering/list changes only; no auth or data-handling changes.
> 
> **Overview**
> The CLI avatar preview no longer fails silently when terminal image rendering isn't supported: **`termImg`** is wrapped in **try/catch**, uses **`fallback: () => imageUrl`** so the image URL can still be shown, and on hard failures prints **`Avatar preview unavailable. URL: …`**.
> 
> Provider resolution lists are updated so **`qq`** and **`whatsapp`** participate in **username** lookups, and **domain** inputs try **`duckduckgo`** and **`google`** before **`microlink`** (previously domain resolution only listed microlink).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86ef7d59de6adff0f8139cdf436e2c957e03645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->