### PR TITLE
fix(dribbble): use desktop browser user agent

### DIFF
--- a/src/providers/dribbble.js
+++ b/src/providers/dribbble.js
@@ -1,8 +1,17 @@
 'use strict'
 
+const uniqueRandomArray = require('unique-random-array')
+
+/**
+ * Dribbble answers 403 to crawler/bot user agents, so a real desktop
+ * browser user agent is required to reach the profile markup.
+ */
+const randomUserAgent = uniqueRandomArray(require('top-user-agents'))
+
 module.exports = ({ createHtmlProvider }) =>
   createHtmlProvider({
     name: 'dribbble',
     url: input => `https://dribbble.com/${input}`,
-    getter: $ => $('.profile-avatar').attr('src')
+    getter: $ => $('.profile-avatar').attr('src'),
+    htmlOpts: () => ({ headers: { 'user-agent': randomUserAgent() } })
   })


### PR DESCRIPTION
Dribbble answers 403 to crawler/bot user agents, including the Slackbot UA the API sets as the default for every provider, so the profile markup was never reached and dribbble resolved to the fallback. Send a random desktop browser user agent via htmlOpts, mirroring the soundcloud provider pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-provider fetch header change with no auth, data, or shared infrastructure impact.
> 
> **Overview**
> **Fixes Dribbble avatar resolution** by sending a random desktop browser `User-Agent` on HTML fetches instead of the API default (Slackbot), which Dribbble blocks with 403.
> 
> The dribbble provider now passes `htmlOpts` with `headers['user-agent']` from `unique-random-array` + `top-user-agents`, following the same approach as the SoundCloud provider (which uses mobile UAs for a different reason).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715c810e8515a2679acdcce24a224c6c81d455df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->