### PR TITLE
fix(duckduckgo): recover favicons indexed under www host (#629)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ module.exports = ({
     getOgImage,
     NOT_FOUND,
     got,
+    reachableUrl,
     isReservedIp,
     githubSearchCache: cache.githubSearchCache,
     itunesSearchCache: cache.itunesSearchCache

--- a/src/providers/duckduckgo.js
+++ b/src/providers/duckduckgo.js
@@ -1,6 +1,36 @@
 'use strict'
 
-module.exports = () =>
-  function duckduckgo (input) {
-    return `https://icons.duckduckgo.com/ip3/${input}.ico`
+const getAvatarUrl = host => `https://icons.duckduckgo.com/ip3/${host}.ico`
+
+// DuckDuckGo's icon service is keyed by exact hostname and normalizes
+// www <-> apex only for popular domains. Smaller sites are indexed under the
+// single host their crawler saw (usually the canonical `www.` redirect target),
+// so the other variant 404s. Toggle the prefix to recover it.
+const toggleWww = host =>
+  host.startsWith('www.') ? host.slice(4) : `www.${host}`
+
+module.exports = ({ reachableUrl }) => {
+  const isReachable = async url => {
+    try {
+      const { statusCode } = await reachableUrl(url)
+      return reachableUrl.isReachable({ statusCode })
+    } catch {
+      return false
+    }
   }
+
+  return async function duckduckgo (input) {
+    const primary = getAvatarUrl(input)
+    if (await isReachable(primary)) return primary
+
+    const alternate = getAvatarUrl(toggleWww(input))
+    if (alternate !== primary && (await isReachable(alternate))) {
+      return alternate
+    }
+
+    return primary
+  }
+}
+
+module.exports.getAvatarUrl = getAvatarUrl
+module.exports.toggleWww = toggleWww

--- a/test/unit/providers/duckduckgo.js
+++ b/test/unit/providers/duckduckgo.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const test = require('ava')
+const sinon = require('sinon')
+
+const duckduckgoFactory = require('../../../src/providers/duckduckgo')
+const { getAvatarUrl, toggleWww } = duckduckgoFactory
+
+const ip3 = host => `https://icons.duckduckgo.com/ip3/${host}.ico`
+
+// Builds a reachableUrl stub that reports the given hosts as reachable (HTTP
+// 200) and everything else as a 404, mirroring how DuckDuckGo's `ip3` endpoint
+// answers per exact hostname.
+const stubReachable = (...reachableHosts) => {
+  const set = new Set(reachableHosts.map(ip3))
+  const reachableUrl = sinon.stub().callsFake(async url => ({
+    statusCode: set.has(url) ? 200 : 404,
+    url
+  }))
+  reachableUrl.isReachable = ({ statusCode }) =>
+    statusCode >= 200 && statusCode < 400
+  return reachableUrl
+}
+
+test('.getAvatarUrl builds the ip3 icon URL from the host', t => {
+  t.is(getAvatarUrl('chrisd.ca'), ip3('chrisd.ca'))
+})
+
+test('.toggleWww prepends www to a bare host', t => {
+  t.is(toggleWww('chrisd.ca'), 'www.chrisd.ca')
+})
+
+test('.toggleWww strips www from a www host', t => {
+  t.is(toggleWww('www.chrisd.ca'), 'chrisd.ca')
+})
+
+test('returns the primary URL when the bare host is reachable', async t => {
+  const reachableUrl = stubReachable('winnipegfreepress.com')
+  const duckduckgo = duckduckgoFactory({ reachableUrl })
+
+  t.is(await duckduckgo('winnipegfreepress.com'), ip3('winnipegfreepress.com'))
+  // Only the primary is probed; no wasted www lookup.
+  t.true(reachableUrl.calledOnceWithExactly(ip3('winnipegfreepress.com')))
+})
+
+test('recovers the www variant when only www is reachable (chrisd.ca)', async t => {
+  // chrisd.ca: bare 404, www.chrisd.ca 200 — the issue #629 case.
+  const reachableUrl = stubReachable('www.chrisd.ca')
+  const duckduckgo = duckduckgoFactory({ reachableUrl })
+
+  t.is(await duckduckgo('chrisd.ca'), ip3('www.chrisd.ca'))
+})
+
+test('recovers the apex variant when only apex is reachable', async t => {
+  const reachableUrl = stubReachable('chrisd.ca')
+  const duckduckgo = duckduckgoFactory({ reachableUrl })
+
+  t.is(await duckduckgo('www.chrisd.ca'), ip3('chrisd.ca'))
+})
+
+test('falls back to the primary URL when neither variant is reachable (rabble.ca)', async t => {
+  // rabble.ca: DDG has neither bare nor www — return primary so the caller's
+  // reachability check rejects it uniformly and the race falls to Google.
+  const reachableUrl = stubReachable()
+  const duckduckgo = duckduckgoFactory({ reachableUrl })
+
+  t.is(await duckduckgo('rabble.ca'), ip3('rabble.ca'))
+})
+
+test('treats a probe rejection as unreachable and tries the alternate', async t => {
+  const reachableUrl = sinon.stub()
+  reachableUrl.withArgs(ip3('chrisd.ca')).rejects(new Error('network error'))
+  reachableUrl
+    .withArgs(ip3('www.chrisd.ca'))
+    .resolves({ statusCode: 200, url: ip3('www.chrisd.ca') })
+  reachableUrl.isReachable = ({ statusCode }) =>
+    statusCode >= 200 && statusCode < 400
+  const duckduckgo = duckduckgoFactory({ reachableUrl })
+
+  t.is(await duckduckgo('chrisd.ca'), ip3('www.chrisd.ca'))
+})

--- a/test/unit/providers/url-builders.js
+++ b/test/unit/providers/url-builders.js
@@ -4,7 +4,9 @@ const test = require('ava')
 
 const { AVATAR_SIZE } = require('../../../src/constant')
 
-const duckduckgo = require('../../../src/providers/duckduckgo')({})
+const {
+  getAvatarUrl: duckduckgoUrl
+} = require('../../../src/providers/duckduckgo')
 const github = require('../../../src/providers/github')({
   constants: { AVATAR_SIZE }
 })
@@ -16,7 +18,7 @@ const revolut = require('../../../src/providers/revolut')({})
 
 test('duckduckgo builds favicon URL', t => {
   t.is(
-    duckduckgo('microlink.io'),
+    duckduckgoUrl('microlink.io'),
     'https://icons.duckduckgo.com/ip3/microlink.io.ico'
   )
 })


### PR DESCRIPTION
Closes #629.

## Root cause

DuckDuckGo's `ip3` icon service is keyed by **exact hostname** and only normalizes `www` ↔ apex for popular domains. Smaller sites are indexed under the single host DDG's crawler saw — usually the canonical `www.` redirect target — so the *other* variant returns 404 and the provider drops a favicon it actually has.

Verified against the three domains from the issue:

| domain | `ip3/<host>` | `ip3/www.<host>` | notes |
|---|---|---|---|
| chrisd.ca | 404 | **200 real JPEG** | www-only — was silently dropped |
| rabble.ca | 404 | 404 | DDG has neither → Google/microlink |
| winnipegfreepress.com | 200 real PNG | 200 | apex works, unchanged |

(The reported `winnipegfreepress.com` icon is DDG's genuine 32×32 favicon, not a placeholder — so there is no placeholder-quality bug to fix there.)

## Fix

`src/providers/duckduckgo.js` now probes the requested host and, on a miss, retries the `www`-toggled variant, returning whichever DDG actually serves. When neither is reachable it returns the primary URL so the domain race rejects it uniformly and resolves via Google/microlink.

The provider gains `reachableUrl` from the provider context (added to `providerCtx` in `src/index.js`); probes hit the shared ping cache, so the follow-up validation in `avatar/auto.js` is a cache hit rather than a second network call.

## Result

`unavatar.io/duckduckgo/chrisd.ca` goes from **404 → the real favicon**. Verified end-to-end against live DDG.

## Tests

- New `test/unit/providers/duckduckgo.js` — 8 cases using the three real domains as fixtures (bare hit, www recovery, apex recovery, both-miss fallback, probe-rejection).
- `test/unit/providers/url-builders.js` updated to assert the exported `getAvatarUrl` builder.
- Full suite green (469 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the DuckDuckGo domain provider with existing reachableUrl/ping cache; adds one extra probe only on primary miss.
> 
> **Overview**
> Fixes missing DuckDuckGo favicons when DDG only serves the `ip3` icon for the **www** or **apex** hostname, not the one the caller passed.
> 
> The DuckDuckGo provider is now **async** and uses shared **`reachableUrl`** (wired through `providerCtx` in `index.js`) to probe the primary `ip3` URL, then retry with a **`www` ↔ apex** toggle via `toggleWww`. It returns the first reachable URL, or the primary URL when neither responds so downstream validation and provider fallback behave as before. Helpers **`getAvatarUrl`** and **`toggleWww`** are exported for tests.
> 
> Adds **`test/unit/providers/duckduckgo.js`** (primary hit, alternate recovery, both-miss fallback, probe errors) and updates **`url-builders`** to assert `getAvatarUrl` instead of invoking the provider factory with an empty context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2962ccf653166313eccced7cbd7f195418fba4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DuckDuckGo avatar URL selection by checking hostname variants and using the reachable icon when available.
  * Added fallback handling when reachability checks fail or neither URL variant is available.

* **Tests**
  * Added coverage for hostname variants, fallback behavior, and failed reachability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->