### PR TITLE
fix: refuse reserved addresses before fetching or serving

### DIFF
--- a/src/avatar/auto.js
+++ b/src/avatar/auto.js
@@ -32,14 +32,16 @@ const factory = ({
 }) => {
   const { REQUEST_TIMEOUT } = constants
 
+  const refuseReservedAddress = provider => {
+    throw new ExtendableError({
+      message: 'The URL points to a reserved address.',
+      provider,
+      statusCode: httpStatus.FORBIDDEN
+    })
+  }
+
   const assertPublicUrl = async (url, provider) => {
-    if (await isReservedIp(new URL(url).hostname)) {
-      throw new ExtendableError({
-        message: 'The URL points to a reserved address.',
-        provider,
-        statusCode: httpStatus.FORBIDDEN
-      })
-    }
+    if (await isReservedIp(new URL(url).hostname)) { refuseReservedAddress(provider) }
   }
 
   const getAvatarContent = provider => async output => {
@@ -67,8 +69,9 @@ const factory = ({
 
     await assertPublicUrl(output, provider)
 
-    const { statusCode, url } = await reachableUrl(output)
+    const { statusCode, url, reservedAddress } = await reachableUrl(output)
 
+    if (reservedAddress) refuseReservedAddress(provider)
     await assertPublicUrl(url, provider)
 
     if (!reachableUrl.isReachable({ statusCode })) {

--- a/src/avatar/auto.js
+++ b/src/avatar/auto.js
@@ -23,8 +23,24 @@ const getInputType = input => {
   return 'username'
 }
 
-const factory = ({ constants, providers, providerTiers, reachableUrl }) => {
+const factory = ({
+  constants,
+  providers,
+  providerTiers,
+  reachableUrl,
+  isReservedIp
+}) => {
   const { REQUEST_TIMEOUT } = constants
+
+  const assertPublicUrl = async (url, provider) => {
+    if (await isReservedIp(new URL(url).hostname)) {
+      throw new ExtendableError({
+        message: 'The URL points to a reserved address.',
+        provider,
+        statusCode: httpStatus.FORBIDDEN
+      })
+    }
+  }
 
   const getAvatarContent = provider => async output => {
     if (typeof output !== 'string' || output === '') {
@@ -49,7 +65,11 @@ const factory = ({ constants, providers, providerTiers, reachableUrl }) => {
       })
     }
 
+    await assertPublicUrl(output, provider)
+
     const { statusCode, url } = await reachableUrl(output)
+
+    await assertPublicUrl(url, provider)
 
     if (!reachableUrl.isReachable({ statusCode })) {
       throw new ExtendableError({

--- a/src/avatar/auto.js
+++ b/src/avatar/auto.js
@@ -8,6 +8,7 @@ const isEmail = require('is-email-like')
 const pTimeout = require('p-timeout')
 const pAny = require('p-any')
 
+const { RESERVED_ADDRESS_CODE } = require('../util/is-reserved-ip')
 const httpStatus = require('../util/http-status')
 const isIterable = require('../util/is-iterable')
 const ExtendableError = require('../util/error')
@@ -41,7 +42,9 @@ const factory = ({
   }
 
   const assertPublicUrl = async (url, provider) => {
-    if (await isReservedIp(new URL(url).hostname)) { refuseReservedAddress(provider) }
+    if (await isReservedIp(new URL(url).hostname)) {
+      refuseReservedAddress(provider)
+    }
   }
 
   const getAvatarContent = provider => async output => {
@@ -96,6 +99,9 @@ const factory = ({
       .then(getAvatarContent(provider))
       .catch(error => {
         isIterable.forEach(error, error => {
+          if (error.code === RESERVED_ADDRESS_CODE) {
+            error.statusCode = httpStatus.FORBIDDEN
+          }
           error.statusCode = error.statusCode ?? error.response?.statusCode
           error.provider = provider
         })

--- a/src/index.js
+++ b/src/index.js
@@ -29,23 +29,20 @@ module.exports = ({
     resolver: dnsResolver
   })
   const isReservedIp = require('./util/is-reserved-ip')({ cacheableLookup })
-  const got = require('./util/got')({ cacheableLookup })
+  const got = require('./util/got')({ cacheableLookup, isReservedIp })
   const reachableUrl = require('./util/reachable-url')({
     got,
     pingCache: cache.pingCache
   })
   const createBrowser = require('./util/browserless')(constants)
   const getHTML = require('./util/html-get')({ createBrowser, got })
-  const {
-    createHtmlProvider,
-    getOgImage,
-    NOT_FOUND
-  } = require('./util/html-provider')({
-    ...constants,
-    getHTML,
-    onFetchHTML,
-    userAgent
-  })
+  const { createHtmlProvider, getOgImage, NOT_FOUND } =
+    require('./util/html-provider')({
+      ...constants,
+      getHTML,
+      onFetchHTML,
+      userAgent
+    })
 
   const providerCtx = {
     constants,
@@ -60,15 +57,15 @@ module.exports = ({
     githubSearchCache: cache.githubSearchCache,
     itunesSearchCache: cache.itunesSearchCache
   }
-  const { providers, providerTiers, providersBy } = require('./providers')(
-    providerCtx
-  )
+  const { providers, providerTiers, providersBy } =
+    require('./providers')(providerCtx)
 
   const { auto, getInputType, getAvatar } = require('./avatar/auto')({
     constants,
     providers,
     providerTiers,
-    reachableUrl
+    reachableUrl,
+    isReservedIp
   })
 
   const unavatar = input => auto(getInputType(input))(input, {})

--- a/src/providers/bimi.js
+++ b/src/providers/bimi.js
@@ -4,18 +4,15 @@ const createGetLogo = require('bimi-url')
 
 const parseInput = input => input.slice(input.lastIndexOf('@') + 1)
 
-module.exports = ({ bimiCache, dnsResolver, got, isReservedIp }) => {
+module.exports = ({ bimiCache, dnsResolver, got }) => {
   const getLogo = createGetLogo({
     gotOpts: got.gotOpts,
     keyvOpts: bimiCache,
     resolveTxt: hostname => dnsResolver.resolveTxt(hostname)
   })
 
-  return async function bimi (input) {
-    const logoUrl = await getLogo(parseInput(input))
-    if (!logoUrl) return undefined
-    if (await isReservedIp(new URL(logoUrl).hostname)) return undefined
-    return logoUrl
+  return function bimi (input) {
+    return getLogo(parseInput(input))
   }
 }
 

--- a/src/util/got.js
+++ b/src/util/got.js
@@ -40,12 +40,23 @@ const userAgentHook = options => {
 
 module.exports = ({ cacheableLookup, isReservedIp }) => {
   /**
+   * The refused address is reported on `options.context` because a caller
+   * reading the outcome through `reachable-url` never sees the rejection: it is
+   * swallowed there and served back as a response.
+   *
+   * Only a context the caller owns is written: the one got defaults to is
+   * frozen and shared between requests, so asking to be told is what passing a
+   * context means.
+   *
    * A plain Error is wrapped by got into a RequestError that keeps only the
    * message, so the status code has to travel on an error got lets through.
    */
   const reservedAddressHook = async options => {
     const hostname = options.url?.hostname
     if (hostname && (await isReservedIp(hostname))) {
+      if (Object.isExtensible(options.context)) {
+        options.context.reservedAddress = hostname
+      }
       const error = new got.RequestError(
         `Refusing to request a reserved address: ${hostname}`,
         {},

--- a/src/util/got.js
+++ b/src/util/got.js
@@ -5,6 +5,8 @@ const tlsHook = require('https-tls/hook')
 const uaHints = require('ua-hints')
 const got = require('got')
 
+const httpStatus = require('./http-status')
+
 const topUserAgents = require('top-user-agents')
 const randomUserAgent = uniqueRandomArray(topUserAgents)
 
@@ -37,10 +39,20 @@ const userAgentHook = options => {
 }
 
 module.exports = ({ cacheableLookup, isReservedIp }) => {
+  /**
+   * A plain Error is wrapped by got into a RequestError that keeps only the
+   * message, so the status code has to travel on an error got lets through.
+   */
   const reservedAddressHook = async options => {
     const hostname = options.url?.hostname
     if (hostname && (await isReservedIp(hostname))) {
-      throw new Error(`Refusing to request a reserved address: ${hostname}`)
+      const error = new got.RequestError(
+        `Refusing to request a reserved address: ${hostname}`,
+        {},
+        options
+      )
+      error.statusCode = httpStatus.FORBIDDEN
+      throw error
     }
   }
 

--- a/src/util/got.js
+++ b/src/util/got.js
@@ -36,11 +36,21 @@ const userAgentHook = options => {
   }
 }
 
-module.exports = ({ cacheableLookup }) => {
+module.exports = ({ cacheableLookup, isReservedIp }) => {
+  const reservedAddressHook = async options => {
+    const hostname = options.url?.hostname
+    if (hostname && (await isReservedIp(hostname))) {
+      throw new Error(`Refusing to request a reserved address: ${hostname}`)
+    }
+  }
+
   const gotOpts = {
     dnsCache: cacheableLookup,
     https: { rejectUnauthorized: false },
-    hooks: { beforeRequest: [userAgentHook, tlsHook] }
+    hooks: {
+      beforeRequest: [reservedAddressHook, userAgentHook, tlsHook],
+      beforeRedirect: [reservedAddressHook]
+    }
   }
 
   const instance = got.extend(gotOpts)

--- a/src/util/got.js
+++ b/src/util/got.js
@@ -5,7 +5,7 @@ const tlsHook = require('https-tls/hook')
 const uaHints = require('ua-hints')
 const got = require('got')
 
-const httpStatus = require('./http-status')
+const { RESERVED_ADDRESS_CODE } = require('./is-reserved-ip')
 
 const topUserAgents = require('top-user-agents')
 const randomUserAgent = uniqueRandomArray(topUserAgents)
@@ -48,8 +48,8 @@ module.exports = ({ cacheableLookup, isReservedIp }) => {
    * frozen and shared between requests, so asking to be told is what passing a
    * context means.
    *
-   * A plain Error is wrapped by got into a RequestError that keeps only the
-   * message, so the status code has to travel on an error got lets through.
+   * got replaces the error with a RequestError that keeps the message and the
+   * code, so the refusal is named by a code rather than by its type.
    */
   const reservedAddressHook = async options => {
     const hostname = options.url?.hostname
@@ -57,12 +57,10 @@ module.exports = ({ cacheableLookup, isReservedIp }) => {
       if (Object.isExtensible(options.context)) {
         options.context.reservedAddress = hostname
       }
-      const error = new got.RequestError(
-        `Refusing to request a reserved address: ${hostname}`,
-        {},
-        options
+      const error = new Error(
+        `Refusing to request a reserved address: ${hostname}`
       )
-      error.statusCode = httpStatus.FORBIDDEN
+      error.code = RESERVED_ADDRESS_CODE
       throw error
     }
   }

--- a/src/util/is-reserved-ip.js
+++ b/src/util/is-reserved-ip.js
@@ -21,3 +21,5 @@ module.exports = ({ cacheableLookup }) => {
     return ip.process(ipAddress).range() !== 'unicast'
   }
 }
+
+module.exports.RESERVED_ADDRESS_CODE = 'ERESERVEDADDRESSRANGE'

--- a/src/util/is-reserved-ip.js
+++ b/src/util/is-reserved-ip.js
@@ -2,16 +2,16 @@
 
 const ip = require('ipaddr.js')
 
+const unbracket = hostname =>
+  hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname
+
 module.exports = ({ cacheableLookup }) => {
   const getIpAddress = async hostname => {
     if (ip.IPv4.isIPv4(hostname)) return hostname
-    if (
-      hostname.startsWith('[') &&
-      hostname.endsWith(']') &&
-      ip.IPv6.isIPv6(hostname.slice(1, -1))
-    ) {
-      return hostname.slice(1, -1)
-    }
+    const literal = unbracket(hostname)
+    if (ip.IPv6.isIPv6(literal)) return literal
     const { address } = await cacheableLookup.lookupAsync(hostname)
     return address
   }

--- a/src/util/reachable-url.js
+++ b/src/util/reachable-url.js
@@ -7,11 +7,12 @@ module.exports = ({ got, pingCache }) => {
     value: ({ url, statusCode }) => ({ url, statusCode })
   })
 
-  const reachableUrl = (url, opts) =>
-    pingUrl(url, {
-      ...got.gotOpts,
-      ...opts
-    })
+  const reachableUrl = async (url, opts) => {
+    const context = {}
+    const response = await pingUrl(url, { ...got.gotOpts, ...opts, context })
+    const { reservedAddress } = context
+    return reservedAddress ? { ...response, reservedAddress } : response
+  }
 
   reachableUrl.isReachable = createPingUrl.isReachable
 

--- a/test/unit/avatar/auto.js
+++ b/test/unit/avatar/auto.js
@@ -462,6 +462,31 @@ test('refuses an avatar that redirects onto a reserved address', async t => {
   t.true(reachableUrl.calledOnce)
 })
 
+test('refuses an avatar whose redirect was blocked before connecting', async t => {
+  const provider = sinon.stub().resolves('https://attacker.com/avatar.png')
+  const reachableUrl = sinon.stub().resolves({
+    statusCode: 404,
+    url: 'https://attacker.com/avatar.png',
+    reservedAddress: '127.0.0.1'
+  })
+  reachableUrl.isReachable = sinon.stub().returns(false)
+
+  const { getAvatar } = createAuto({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { bimi: provider },
+    providerTiers: { domain: [['bimi']] },
+    reachableUrl
+  })
+
+  const error = await t.throwsAsync(() =>
+    getAvatar(provider, 'bimi', 'attacker.com', {})
+  )
+
+  t.is(error.statusCode, 403)
+  t.is(error.provider, 'bimi')
+  t.is(error.message, 'The URL points to a reserved address.')
+})
+
 test('refuses an IPv6 reserved address', async t => {
   const provider = sinon.stub().resolves('https://[::1]/avatar.png')
   const reachableUrl = sinon.stub()

--- a/test/unit/avatar/auto.js
+++ b/test/unit/avatar/auto.js
@@ -7,6 +7,9 @@ const proxyquire = require('proxyquire')
 
 const autoFactory = require('../../../src/avatar/auto')
 
+const createAuto = ({ isReservedIp = async () => false, ...options }) =>
+  autoFactory({ ...options, isReservedIp })
+
 test('getInputType classifies email input', t => {
   t.is(autoFactory.getInputType('hello@microlink.io'), 'email')
 })
@@ -54,12 +57,11 @@ test('auto(type) uses the provided input type resolver', async t => {
   })
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { auto } = autoFactory({
+  const { auto } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const resolver = auto('domain')
@@ -83,15 +85,14 @@ test('email hash input routes only to gravatar, not to other email providers', a
   })
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { auto } = autoFactory({
+  const { auto } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { gravatar, github },
     providerTiers: {
       email: [['gravatar', 'github']],
       emailHash: [['gravatar']]
     },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const md5hash = '0bc83cb571cd1c50ba6f3e8a78ef1346'
@@ -118,12 +119,11 @@ const createTiers = ({
   const reachableUrl = async url => ({ statusCode: 200, url })
   reachableUrl.isReachable = () => true
 
-  const { auto } = autoFactory({
+  const { auto } = createAuto({
     constants: { REQUEST_TIMEOUT },
     providers: { primary: provider('primary'), fallback: provider('fallback') },
     providerTiers: { domain: [['primary'], ['fallback']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   return { resolve: auto('domain'), calls }
@@ -210,12 +210,11 @@ test('a provider reached with the budget already spent times out at once', async
   const reachableUrl = () => {}
   reachableUrl.isReachable = () => true
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT },
     providers: {},
     providerTiers: {},
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const spent = Date.now() - 1000
@@ -238,12 +237,11 @@ test('an input type with no providers declared reports not found', async t => {
   const reachableUrl = () => {}
   reachableUrl.isReachable = () => true
 
-  const { auto } = autoFactory({
+  const { auto } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: {},
     providerTiers: { email: [['gravatar']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(auto('email')('0'.repeat(32), {}))
@@ -266,12 +264,11 @@ test('getAvatar throws "not found" when provider returns undefined', async t => 
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -287,12 +284,11 @@ test('getAvatar throws "invalid" when provider returns a non-string value', asyn
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -308,12 +304,11 @@ test('getAvatar throws "invalid" when provider returns an empty string', async t
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -328,12 +323,11 @@ test('getAvatar throws when provider returns a non-absolute URL', async t => {
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -351,12 +345,11 @@ test('getAvatar throws when the resolved URL is not reachable', async t => {
     .resolves({ statusCode: 404, url: 'https://example.com/avatar.png' })
   reachableUrl.isReachable = sinon.stub().returns(false)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -374,12 +367,11 @@ test('getAvatar sets provider on error from response.statusCode when statusCode 
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl,
-    isReservedIp: async () => false
+    reachableUrl
   })
 
   const error = await t.throwsAsync(() =>
@@ -427,7 +419,7 @@ test('refuses an avatar hosted on a reserved address before fetching it', async 
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { bimi: provider },
     providerTiers: { domain: [['bimi']] },
@@ -453,7 +445,7 @@ test('refuses an avatar that redirects onto a reserved address', async t => {
   })
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { bimi: provider },
     providerTiers: { domain: [['bimi']] },
@@ -475,7 +467,7 @@ test('refuses an IPv6 reserved address', async t => {
   const reachableUrl = sinon.stub()
   reachableUrl.isReachable = sinon.stub().returns(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { bimi: provider },
     providerTiers: { domain: [['bimi']] },
@@ -497,7 +489,7 @@ test('a data URI avatar skips the reserved address check', async t => {
   reachableUrl.isReachable = sinon.stub().returns(true)
   const isReservedIp = sinon.stub().resolves(true)
 
-  const { getAvatar } = autoFactory({
+  const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { gravatar: provider },
     providerTiers: { email: [['gravatar']] },

--- a/test/unit/avatar/auto.js
+++ b/test/unit/avatar/auto.js
@@ -58,7 +58,8 @@ test('auto(type) uses the provided input type resolver', async t => {
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const resolver = auto('domain')
@@ -89,7 +90,8 @@ test('email hash input routes only to gravatar, not to other email providers', a
       email: [['gravatar', 'github']],
       emailHash: [['gravatar']]
     },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const md5hash = '0bc83cb571cd1c50ba6f3e8a78ef1346'
@@ -120,7 +122,8 @@ const createTiers = ({
     constants: { REQUEST_TIMEOUT },
     providers: { primary: provider('primary'), fallback: provider('fallback') },
     providerTiers: { domain: [['primary'], ['fallback']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   return { resolve: auto('domain'), calls }
@@ -211,7 +214,8 @@ test('a provider reached with the budget already spent times out at once', async
     constants: { REQUEST_TIMEOUT },
     providers: {},
     providerTiers: {},
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const spent = Date.now() - 1000
@@ -238,7 +242,8 @@ test('an input type with no providers declared reports not found', async t => {
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: {},
     providerTiers: { email: [['gravatar']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(auto('email')('0'.repeat(32), {}))
@@ -265,7 +270,8 @@ test('getAvatar throws "not found" when provider returns undefined', async t => 
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -285,7 +291,8 @@ test('getAvatar throws "invalid" when provider returns a non-string value', asyn
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -305,7 +312,8 @@ test('getAvatar throws "invalid" when provider returns an empty string', async t
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -324,7 +332,8 @@ test('getAvatar throws when provider returns a non-absolute URL', async t => {
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -346,7 +355,8 @@ test('getAvatar throws when the resolved URL is not reachable', async t => {
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -368,7 +378,8 @@ test('getAvatar sets provider on error from response.statusCode when statusCode 
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const error = await t.throwsAsync(() =>
@@ -394,7 +405,8 @@ test('auto(type) is deterministic with stateful data URI regex', async t => {
     constants: { REQUEST_TIMEOUT: 25000 },
     providers: { google: provider },
     providerTiers: { domain: [['google']] },
-    reachableUrl
+    reachableUrl,
+    isReservedIp: async () => false
   })
 
   const resolver = auto('domain')
@@ -408,4 +420,94 @@ test('auto(type) is deterministic with stateful data URI regex', async t => {
     data: 'data:image/png;base64,AAAA'
   })
   t.true(reachableUrl.notCalled)
+})
+
+test('refuses an avatar hosted on a reserved address before fetching it', async t => {
+  const provider = sinon.stub().resolves('https://127.0.0.1/avatar.png')
+  const reachableUrl = sinon.stub()
+  reachableUrl.isReachable = sinon.stub().returns(true)
+
+  const { getAvatar } = autoFactory({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { bimi: provider },
+    providerTiers: { domain: [['bimi']] },
+    reachableUrl,
+    isReservedIp: async hostname => hostname === '127.0.0.1'
+  })
+
+  const error = await t.throwsAsync(() =>
+    getAvatar(provider, 'bimi', 'attacker.com', {})
+  )
+
+  t.is(error.statusCode, 403)
+  t.is(error.provider, 'bimi')
+  t.is(error.message, 'The URL points to a reserved address.')
+  t.true(reachableUrl.notCalled)
+})
+
+test('refuses an avatar that redirects onto a reserved address', async t => {
+  const provider = sinon.stub().resolves('https://attacker.com/avatar.png')
+  const reachableUrl = sinon.stub().resolves({
+    statusCode: 200,
+    url: 'https://169.254.169.254/avatar.png'
+  })
+  reachableUrl.isReachable = sinon.stub().returns(true)
+
+  const { getAvatar } = autoFactory({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { bimi: provider },
+    providerTiers: { domain: [['bimi']] },
+    reachableUrl,
+    isReservedIp: async hostname => hostname === '169.254.169.254'
+  })
+
+  const error = await t.throwsAsync(() =>
+    getAvatar(provider, 'bimi', 'attacker.com', {})
+  )
+
+  t.is(error.statusCode, 403)
+  t.is(error.provider, 'bimi')
+  t.true(reachableUrl.calledOnce)
+})
+
+test('refuses an IPv6 reserved address', async t => {
+  const provider = sinon.stub().resolves('https://[::1]/avatar.png')
+  const reachableUrl = sinon.stub()
+  reachableUrl.isReachable = sinon.stub().returns(true)
+
+  const { getAvatar } = autoFactory({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { bimi: provider },
+    providerTiers: { domain: [['bimi']] },
+    reachableUrl,
+    isReservedIp: async hostname => hostname === '[::1]'
+  })
+
+  const error = await t.throwsAsync(() =>
+    getAvatar(provider, 'bimi', 'attacker.com', {})
+  )
+
+  t.is(error.statusCode, 403)
+  t.true(reachableUrl.notCalled)
+})
+
+test('a data URI avatar skips the reserved address check', async t => {
+  const provider = sinon.stub().resolves('data:image/png;base64,AAAA')
+  const reachableUrl = sinon.stub()
+  reachableUrl.isReachable = sinon.stub().returns(true)
+  const isReservedIp = sinon.stub().resolves(true)
+
+  const { getAvatar } = autoFactory({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { gravatar: provider },
+    providerTiers: { email: [['gravatar']] },
+    reachableUrl,
+    isReservedIp
+  })
+
+  t.deepEqual(await getAvatar(provider, 'gravatar', 'hello@microlink.io', {}), {
+    type: 'buffer',
+    data: 'data:image/png;base64,AAAA'
+  })
+  t.true(isReservedIp.notCalled)
 })

--- a/test/unit/avatar/auto.js
+++ b/test/unit/avatar/auto.js
@@ -487,6 +487,31 @@ test('refuses an avatar whose redirect was blocked before connecting', async t =
   t.is(error.message, 'The URL points to a reserved address.')
 })
 
+test('a provider refused by got surfaces as forbidden, not as a fatal error', async t => {
+  const refused = Object.assign(
+    new Error('Refusing to request a reserved address: 127.0.0.1'),
+    { code: 'ERESERVEDADDRESSRANGE' }
+  )
+  const provider = sinon.stub().rejects(refused)
+  const reachableUrl = sinon.stub()
+  reachableUrl.isReachable = sinon.stub().returns(true)
+
+  const { getAvatar } = createAuto({
+    constants: { REQUEST_TIMEOUT: 25000 },
+    providers: { mastodon: provider },
+    providerTiers: { username: [['mastodon']] },
+    reachableUrl
+  })
+
+  const error = await t.throwsAsync(() =>
+    getAvatar(provider, 'mastodon', 'user@attacker.com', {})
+  )
+
+  t.is(error.statusCode, 403)
+  t.is(error.provider, 'mastodon')
+  t.true(reachableUrl.notCalled)
+})
+
 test('refuses an IPv6 reserved address', async t => {
   const provider = sinon.stub().resolves('https://[::1]/avatar.png')
   const reachableUrl = sinon.stub()

--- a/test/unit/providers/bimi.js
+++ b/test/unit/providers/bimi.js
@@ -8,10 +8,7 @@ const { parseInput } = require('../../../src/providers/bimi')
 
 const LOGO_URL = 'https://cdn.microlink.io/logo/logo.svg'
 
-const createProvider = ({
-  logos = {},
-  isReservedIp = async () => false
-} = {}) => {
+const createProvider = ({ logos = {} } = {}) => {
   let received
 
   const createGetLogo = options => {
@@ -25,7 +22,7 @@ const createProvider = ({
 
   const bimi = proxyquire('../../../src/providers/bimi', {
     'bimi-url': createGetLogo
-  })({ bimiCache, dnsResolver, got: { gotOpts }, isReservedIp })
+  })({ bimiCache, dnsResolver, got: { gotOpts } })
 
   return { bimi, received, bimiCache, gotOpts }
 }
@@ -62,13 +59,4 @@ test('returns undefined when the domain publishes no record', async t => {
   const { bimi } = createProvider()
 
   t.is(await bimi('example.com'), undefined)
-})
-
-test('refuses a logo hosted on a reserved address', async t => {
-  const { bimi } = createProvider({
-    logos: { 'shopify.com': 'https://127.0.0.1/logo.svg' },
-    isReservedIp: async () => true
-  })
-
-  t.is(await bimi('shopify.com'), undefined)
 })

--- a/test/unit/util/got.js
+++ b/test/unit/util/got.js
@@ -74,6 +74,18 @@ test('got util refuses a request to a reserved address', async t => {
   t.deepEqual(isReservedIp.args, [['127.0.0.1'], ['cdn.microlink.io']])
 })
 
+test('the refused address is recorded on the request context', async t => {
+  const { got } = buildGot({ isReservedIp: async () => true })
+  const reservedAddressHook = got.gotOpts.hooks.beforeRedirect[0]
+  const context = {}
+
+  await t.throwsAsync(
+    reservedAddressHook({ url: new URL('https://169.254.169.254/x'), context })
+  )
+
+  t.is(context.reservedAddress, '169.254.169.254')
+})
+
 test('got util refuses a redirect onto a reserved address', async t => {
   const isReservedIp = sinon
     .stub()

--- a/test/unit/util/got.js
+++ b/test/unit/util/got.js
@@ -3,6 +3,9 @@
 const test = require('ava')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+const { RequestError } = require('got')
+
+const createGot = require('../../../src/util/got')
 
 const buildGot = ({ isReservedIp = async () => false } = {}) => {
   const uaHints = sinon
@@ -18,7 +21,7 @@ const buildGot = ({ isReservedIp = async () => false } = {}) => {
     'top-user-agents': ['agent-a', 'agent-b'],
     'unique-random-array': uniqueRandomArray,
     'https-tls/hook': tlsHook,
-    got: { extend: gotExtend }
+    got: { extend: gotExtend, RequestError }
   })
 
   const got = gotFactory({ cacheableLookup: 'dns-cache', isReservedIp })
@@ -60,7 +63,8 @@ test('got util refuses a request to a reserved address', async t => {
   await t.throwsAsync(
     reservedAddressHook({ url: new URL('https://127.0.0.1/logo.svg') }),
     {
-      message: 'Refusing to request a reserved address: 127.0.0.1'
+      message: 'Refusing to request a reserved address: 127.0.0.1',
+      instanceOf: RequestError
     }
   )
   await t.notThrowsAsync(
@@ -83,6 +87,18 @@ test('got util refuses a redirect onto a reserved address', async t => {
       message: 'Refusing to request a reserved address: [::1]'
     }
   )
+})
+
+test('the reserved address error keeps its status code through got', async t => {
+  const got = createGot({
+    cacheableLookup: undefined,
+    isReservedIp: async () => true
+  })
+
+  const error = await t.throwsAsync(got('https://127.0.0.1/logo.svg'))
+
+  t.is(error.statusCode, 403)
+  t.is(error.message, 'Refusing to request a reserved address: 127.0.0.1')
 })
 
 test('got util uses precomputed ua hints for top user agents', t => {

--- a/test/unit/util/got.js
+++ b/test/unit/util/got.js
@@ -3,8 +3,6 @@
 const test = require('ava')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
-const { RequestError } = require('got')
-
 const createGot = require('../../../src/util/got')
 
 const buildGot = ({ isReservedIp = async () => false } = {}) => {
@@ -21,7 +19,7 @@ const buildGot = ({ isReservedIp = async () => false } = {}) => {
     'top-user-agents': ['agent-a', 'agent-b'],
     'unique-random-array': uniqueRandomArray,
     'https-tls/hook': tlsHook,
-    got: { extend: gotExtend, RequestError }
+    got: { extend: gotExtend }
   })
 
   const got = gotFactory({ cacheableLookup: 'dns-cache', isReservedIp })
@@ -64,7 +62,7 @@ test('got util refuses a request to a reserved address', async t => {
     reservedAddressHook({ url: new URL('https://127.0.0.1/logo.svg') }),
     {
       message: 'Refusing to request a reserved address: 127.0.0.1',
-      instanceOf: RequestError
+      code: 'ERESERVEDADDRESSRANGE'
     }
   )
   await t.notThrowsAsync(
@@ -101,7 +99,7 @@ test('got util refuses a redirect onto a reserved address', async t => {
   )
 })
 
-test('the reserved address error keeps its status code through got', async t => {
+test('the reserved address error keeps its code through got', async t => {
   const got = createGot({
     cacheableLookup: undefined,
     isReservedIp: async () => true
@@ -109,7 +107,7 @@ test('the reserved address error keeps its status code through got', async t => 
 
   const error = await t.throwsAsync(got('https://127.0.0.1/logo.svg'))
 
-  t.is(error.statusCode, 403)
+  t.is(error.code, 'ERESERVEDADDRESSRANGE')
   t.is(error.message, 'Refusing to request a reserved address: 127.0.0.1')
 })
 

--- a/test/unit/util/got.js
+++ b/test/unit/util/got.js
@@ -4,8 +4,10 @@ const test = require('ava')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
-const buildGot = () => {
-  const uaHints = sinon.stub().callsFake(userAgent => ({ 'sec-ch-ua': `"${userAgent}"` }))
+const buildGot = ({ isReservedIp = async () => false } = {}) => {
+  const uaHints = sinon
+    .stub()
+    .callsFake(userAgent => ({ 'sec-ch-ua': `"${userAgent}"` }))
   const randomUserAgent = sinon.stub().returns('custom-agent')
   const uniqueRandomArray = sinon.stub().returns(randomUserAgent)
   const tlsHook = sinon.stub()
@@ -19,9 +21,16 @@ const buildGot = () => {
     got: { extend: gotExtend }
   })
 
-  const got = gotFactory({ cacheableLookup: 'dns-cache' })
+  const got = gotFactory({ cacheableLookup: 'dns-cache', isReservedIp })
 
-  return { got, gotExtend, uaHints, randomUserAgent, uniqueRandomArray, tlsHook }
+  return {
+    got,
+    gotExtend,
+    uaHints,
+    randomUserAgent,
+    uniqueRandomArray,
+    tlsHook
+  }
 }
 
 test('got util creates instance with dns cache and hooks', t => {
@@ -34,14 +43,51 @@ test('got util creates instance with dns cache and hooks', t => {
   t.is(gotOpts.dnsCache, 'dns-cache')
   t.deepEqual(gotOpts.https, { rejectUnauthorized: false })
   t.true(Array.isArray(gotOpts.hooks.beforeRequest))
-  t.is(gotOpts.hooks.beforeRequest.length, 2)
-  t.is(gotOpts.hooks.beforeRequest[1], tlsHook)
+  t.is(gotOpts.hooks.beforeRequest.length, 3)
+  t.is(gotOpts.hooks.beforeRequest[2], tlsHook)
+  t.is(gotOpts.hooks.beforeRedirect.length, 1)
+  t.is(gotOpts.hooks.beforeRedirect[0], gotOpts.hooks.beforeRequest[0])
   t.is(got.gotOpts, gotOpts)
+})
+
+test('got util refuses a request to a reserved address', async t => {
+  const isReservedIp = sinon
+    .stub()
+    .callsFake(async hostname => hostname === '127.0.0.1')
+  const { got } = buildGot({ isReservedIp })
+  const reservedAddressHook = got.gotOpts.hooks.beforeRequest[0]
+
+  await t.throwsAsync(
+    reservedAddressHook({ url: new URL('https://127.0.0.1/logo.svg') }),
+    {
+      message: 'Refusing to request a reserved address: 127.0.0.1'
+    }
+  )
+  await t.notThrowsAsync(
+    reservedAddressHook({ url: new URL('https://cdn.microlink.io/logo.svg') })
+  )
+  await t.notThrowsAsync(reservedAddressHook({}))
+  t.deepEqual(isReservedIp.args, [['127.0.0.1'], ['cdn.microlink.io']])
+})
+
+test('got util refuses a redirect onto a reserved address', async t => {
+  const isReservedIp = sinon
+    .stub()
+    .callsFake(async hostname => hostname === '[::1]')
+  const { got } = buildGot({ isReservedIp })
+  const reservedAddressHook = got.gotOpts.hooks.beforeRedirect[0]
+
+  await t.throwsAsync(
+    reservedAddressHook({ url: new URL('https://[::1]/logo.svg') }),
+    {
+      message: 'Refusing to request a reserved address: [::1]'
+    }
+  )
 })
 
 test('got util uses precomputed ua hints for top user agents', t => {
   const { got, uaHints } = buildGot()
-  const userAgentHook = got.gotOpts.hooks.beforeRequest[0]
+  const userAgentHook = got.gotOpts.hooks.beforeRequest[1]
 
   uaHints.resetHistory()
 
@@ -58,7 +104,7 @@ test('got util uses precomputed ua hints for top user agents', t => {
 
 test('got util computes ua hints for non-top user agents per request', t => {
   const { got, uaHints } = buildGot()
-  const userAgentHook = got.gotOpts.hooks.beforeRequest[0]
+  const userAgentHook = got.gotOpts.hooks.beforeRequest[1]
 
   uaHints.resetHistory()
 
@@ -70,8 +116,10 @@ test('got util computes ua hints for non-top user agents per request', t => {
 
 test('got util replaces default got user agent before computing hints', t => {
   const { got, uaHints, randomUserAgent } = buildGot()
-  const userAgentHook = got.gotOpts.hooks.beforeRequest[0]
-  const options = { headers: { 'user-agent': 'got (https://github.com/sindresorhus/got)' } }
+  const userAgentHook = got.gotOpts.hooks.beforeRequest[1]
+  const options = {
+    headers: { 'user-agent': 'got (https://github.com/sindresorhus/got)' }
+  }
 
   uaHints.resetHistory()
   userAgentHook(options)

--- a/test/unit/util/is-reserved-ip.js
+++ b/test/unit/util/is-reserved-ip.js
@@ -59,3 +59,10 @@ test('returns false for public unicast addresses', async t => {
 test('returns false for bracketed public IPv6 unicast', async t => {
   t.false(await isReservedIp('[2001:4860:4860::8888]'))
 })
+
+test('reads an IPv6 literal with or without brackets', async t => {
+  t.true(await isReservedIp('::1'))
+  t.true(await isReservedIp('fd00::1'))
+  t.true(await isReservedIp('fe80::1'))
+  t.false(await isReservedIp('2001:4860:4860::8888'))
+})

--- a/test/unit/util/reachable-url.js
+++ b/test/unit/util/reachable-url.js
@@ -5,16 +5,25 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire').noPreserveCache()
 
 test('reachable-url composes ping-url with cache and merged got options', async t => {
-  const ping = sinon.stub().resolves({ statusCode: 200, url: 'https://example.com' })
+  const ping = sinon
+    .stub()
+    .resolves({ statusCode: 200, url: 'https://example.com' })
   const pingCache = { name: 'ping-cache' }
 
   const createPingUrl = sinon.stub().callsFake((cache, opts) => {
     t.deepEqual(cache, pingCache)
     t.is(typeof opts.value, 'function')
-    t.deepEqual(opts.value({ url: 'https://example.com', statusCode: 200, ignored: true }), {
-      url: 'https://example.com',
-      statusCode: 200
-    })
+    t.deepEqual(
+      opts.value({
+        url: 'https://example.com',
+        statusCode: 200,
+        ignored: true
+      }),
+      {
+        url: 'https://example.com',
+        statusCode: 200
+      }
+    )
     return ping
   })
   createPingUrl.isReachable = sinon.stub().returns(true)
@@ -28,14 +37,78 @@ test('reachable-url composes ping-url with cache and merged got options', async 
     pingCache
   })
 
-  const value = await reachableUrl('https://example.com/avatar.png', { retry: { limit: 1 } })
+  const value = await reachableUrl('https://example.com/avatar.png', {
+    retry: { limit: 1 }
+  })
 
   t.deepEqual(value, { statusCode: 200, url: 'https://example.com' })
   t.true(
     ping.calledOnceWithExactly('https://example.com/avatar.png', {
       timeout: 1234,
-      retry: { limit: 1 }
+      retry: { limit: 1 },
+      context: {}
     })
   )
   t.true(reachableUrl.isReachable())
+})
+
+test('reports the address a refused redirect was pointing at', async t => {
+  const ping = sinon.stub().callsFake(async (url, { context }) => {
+    context.reservedAddress = '127.0.0.1'
+    return { statusCode: 404, url }
+  })
+
+  const createPingUrl = sinon.stub().returns(ping)
+  createPingUrl.isReachable = sinon.stub().returns(true)
+
+  const reachableUrl = proxyquire('../../../src/util/reachable-url', {
+    '@microlink/ping-url': createPingUrl
+  })({ got: { gotOpts: {} }, pingCache: {} })
+
+  t.deepEqual(await reachableUrl('https://attacker.com/avatar.png'), {
+    statusCode: 404,
+    url: 'https://attacker.com/avatar.png',
+    reservedAddress: '127.0.0.1'
+  })
+})
+
+test('a request that is not refused carries no reserved address', async t => {
+  const ping = sinon
+    .stub()
+    .resolves({ statusCode: 200, url: 'https://example.com' })
+
+  const createPingUrl = sinon.stub().returns(ping)
+  createPingUrl.isReachable = sinon.stub().returns(true)
+
+  const reachableUrl = proxyquire('../../../src/util/reachable-url', {
+    '@microlink/ping-url': createPingUrl
+  })({ got: { gotOpts: {} }, pingCache: {} })
+
+  t.deepEqual(await reachableUrl('https://example.com/avatar.png'), {
+    statusCode: 200,
+    url: 'https://example.com'
+  })
+})
+
+test('each call gets its own context', async t => {
+  const contexts = []
+  const ping = sinon.stub().callsFake(async (url, { context }) => {
+    contexts.push(context)
+    return { statusCode: 200, url }
+  })
+
+  const createPingUrl = sinon.stub().returns(ping)
+  createPingUrl.isReachable = sinon.stub().returns(true)
+
+  const reachableUrl = proxyquire('../../../src/util/reachable-url', {
+    '@microlink/ping-url': createPingUrl
+  })({ got: { gotOpts: {} }, pingCache: {} })
+
+  await Promise.all([
+    reachableUrl('https://a.example/avatar.png'),
+    reachableUrl('https://b.example/avatar.png')
+  ])
+
+  t.is(contexts.length, 2)
+  t.not(contexts[0], contexts[1])
 })


### PR DESCRIPTION
Alternative to #637, which added the reserved-address check inside the BIMI provider. The check belongs where every provider converges, not in each one.

## What changed

**`src/avatar/auto.js`** — `getAvatarContent` asserts the URL is public twice: on what the provider returns, before `reachableUrl` opens a connection, and on the URL redirects resolve it to, before it is served. Denial is `403 The URL points to a reserved address.` tagged with the provider. Data URIs short-circuit earlier, so no needless lookup.

**`src/util/got.js`** — the shared `gotOpts` deny reserved addresses on `beforeRequest` and `beforeRedirect`, sharing the `isReservedIp` instance (and its DNS cache) with the serving check. This reaches the fetches providers delegate to third parties: `bimi-url` probes the published `l=` URL through `reachable-url`, which merges our hooks into its own got instance, so the probe is refused and degrades to unreachable rather than connecting.

**`src/providers/bimi.js`** — provider-level check removed, now covered centrally.

**`src/providers/mastodon.js`** — untouched on purpose. Its check guards the API call to a user-supplied server host, not the image being served.

## Validation

Unit: 490 passed.

End to end against a real got instance, confirming hook propagation into `reachable-url`:

```
direct got: Refusing to request a reserved address: 127.0.0.1
bimi-url probe path statusCode: 404
```

New cases in `test/unit/avatar/auto.js` (reserved host pre-fetch with `reachableUrl.notCalled`, redirect onto `169.254.169.254`, IPv6 `[::1]`, data URI skips the check) and `test/unit/util/got.js` (request deny, redirect deny, missing url is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7dThgHp7ZfTbzvtMfJiW9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the security boundary for all outbound URL fetches and avatar serving; misclassification could block valid assets or leave SSRF gaps on redirects/DNS.
> 
> **Overview**
> **Centralizes SSRF-style protection** so every provider path is covered, instead of checking only in the BIMI provider.
> 
> **`getAvatarContent`** now validates provider URLs with `isReservedIp` **before** `reachableUrl` runs, again on the post-redirect URL, and returns **403** when the target is non-unicast. Data URIs still bypass HTTP checks. Provider errors with `ERESERVEDADDRESSRANGE` from got are normalized to **403**.
> 
> The shared **got** client adds **`beforeRequest` / `beforeRedirect`** hooks that refuse reserved hostnames, set `context.reservedAddress` when the caller passes an extensible context, and throw with **`ERESERVEDADDRESSRANGE`**. **`reachable-url`** always supplies a per-call `context` and forwards `reservedAddress` when a redirect was blocked without connecting.
> 
> **`is-reserved-ip`** gains bracket-stripping for IPv6 literals and exports the reserved-address error code. BIMI no longer filters logo URLs locally—enforcement happens in auto + got hooks wired from **`index.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0d7494427625d78ea3d19274bd7f6cfc779d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added protection against requests to reserved IPv4 and IPv6 addresses.
  - Blocked redirects to reserved destinations with an HTTP 403 response.
  - Avatar URL validation now checks provider results and final reachable URLs.
  - Improved handling of bracketed IPv6 addresses.
  - Applied safeguards consistently across external URL requests.
  - Data URIs remain supported.

- **Bug Fixes**
  - Preserved valid requests to publicly accessible destinations while rejecting unsafe URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->