### PR TITLE
refactor: use the shared isReachable predicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@keyvhq/redis": "~2.2.3",
     "@metascraper/helpers": "~5.52.0",
     "@microlink/mql": "~0.17.0",
-    "@microlink/ping-url": "~1.4.16",
+    "@microlink/ping-url": "~1.5.0",
     "bimi-url": "~1.0.0",
     "browserless": "~13.6.0",
     "cacheable-lookup": "~6.1.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 minimumReleaseAgeExclude:
   - bimi-url@1.0.0
+  - '@microlink/ping-url@1.5.0'

--- a/src/avatar/auto.js
+++ b/src/avatar/auto.js
@@ -77,8 +77,7 @@ const factory = ({
     if (reservedAddress) refuseReservedAddress(provider)
     await assertPublicUrl(url, provider)
 
-    // `isReachable` accepts 3xx, but here that is an unfinished redirect.
-    if (statusCode < 200 || statusCode >= 300) {
+    if (!reachableUrl.isReachable({ statusCode })) {
       throw new ExtendableError({
         message: httpStatus(statusCode),
         provider,

--- a/test/unit/avatar/auto.js
+++ b/test/unit/avatar/auto.js
@@ -5,6 +5,8 @@ const test = require('ava')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const { isReachable } = require('@microlink/ping-url')
+
 const autoFactory = require('../../../src/avatar/auto')
 
 const createAuto = ({ isReservedIp = async () => false, ...options }) =>
@@ -493,7 +495,7 @@ test('refuses a cached redirect hop that lost the reserved-address signal', asyn
     statusCode: 302,
     url: 'https://attacker.com/avatar.png'
   })
-  reachableUrl.isReachable = sinon.stub().returns(true)
+  reachableUrl.isReachable = isReachable
 
   const { getAvatar } = createAuto({
     constants: { REQUEST_TIMEOUT: 25000 },

--- a/test/unit/providers/duckduckgo.js
+++ b/test/unit/providers/duckduckgo.js
@@ -3,6 +3,8 @@
 const test = require('ava')
 const sinon = require('sinon')
 
+const { isReachable } = require('@microlink/ping-url')
+
 const duckduckgoFactory = require('../../../src/providers/duckduckgo')
 const { getAvatarUrl, toggleWww } = duckduckgoFactory
 
@@ -17,8 +19,7 @@ const stubReachable = (...reachableHosts) => {
     statusCode: set.has(url) ? 200 : 404,
     url
   }))
-  reachableUrl.isReachable = ({ statusCode }) =>
-    statusCode >= 200 && statusCode < 400
+  reachableUrl.isReachable = isReachable
   return reachableUrl
 }
 
@@ -73,8 +74,7 @@ test('treats a probe rejection as unreachable and tries the alternate', async t 
   reachableUrl
     .withArgs(ip3('www.chrisd.ca'))
     .resolves({ statusCode: 200, url: ip3('www.chrisd.ca') })
-  reachableUrl.isReachable = ({ statusCode }) =>
-    statusCode >= 200 && statusCode < 400
+  reachableUrl.isReachable = isReachable
   const duckduckgo = duckduckgoFactory({ reachableUrl })
 
   t.is(await duckduckgo('chrisd.ca'), ip3('www.chrisd.ca'))


### PR DESCRIPTION
Stacked on #639. Unblocked by microlinkhq/ping-url#48, released as 1.5.0.

## Why

`src/avatar/auto.js` spells the reachability rule out inline:

```js
if (statusCode < 200 || statusCode >= 300) {
```

because the pinned `reachable-url@1.8.4` — reached through `@microlink/ping-url@~1.4.16` — defines `isReachable` as `statusCode >= 200 && statusCode < 400`, which accepts a bare 3xx. `src/providers/duckduckgo.js:16` kept calling `isReachable` and therefore disagreed with `auto.js` about the same question.

`@microlink/ping-url@1.5.0` re-exports `reachable-url@2`'s predicate:

```js
const isReachable = ({ statusCode, followRedirect = true }) =>
  statusCode >= 200 && statusCode < (followRedirect ? 300 : 400)
```

That is exactly what `auto.js` hand-rolls, so the rule goes back to living in one place.

## What

- `@microlink/ping-url` `~1.4.16` → `~1.5.0`, plus the matching `minimumReleaseAgeExclude` entry alongside the existing `bimi-url@1.0.0`
- `src/avatar/auto.js` calls `reachableUrl.isReachable({ statusCode })` again; the comment explaining the divergence goes away
- The unit tests stop stubbing `isReachable` with a hand-written copy of the rule and use the real predicate, so a regression in the dependency now fails the suite instead of being masked by the stub

The 3xx → 404 rewrite in `src/util/reachable-url.js` stays. It is not redundant with the predicate: the ping cache memoizes `{ url, statusCode }` and drops `context.reservedAddress`, so normalizing at the cache boundary is what keeps a replayed refusal from looking like an ordinary probe.

## Test

```
500 tests passed
```

Resolved tree confirms the predicate: `isReachable({ statusCode: 302 })` is now `false`, `isReachable({ statusCode: 302, followRedirect: false })` is `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTbj6CYXGsk6rhXx7J8SUP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency bump and delegating reachability to a shared helper; behavior is intentionally tightened for 3xx and covered by existing unit tests.
> 
> **Overview**
> **Upgrades `@microlink/ping-url` to ~1.5.0** (with a matching `minimumReleaseAgeExclude`) so avatar code can use one shared **`isReachable`** rule instead of duplicating status-code logic.
> 
> In **`src/avatar/auto.js`**, the hand-rolled check that rejected non-2xx responses (treating bare 3xx as unreachable) is replaced by **`reachableUrl.isReachable({ statusCode })`**, matching DuckDuckGo and the util wrapper again.
> 
> Unit tests for avatar auto and DuckDuckGo **stop stubbing `isReachable` with a local copy** of the rule and import the real predicate from `@microlink/ping-url`, so behavior tracks the dependency (e.g. **302 is unreachable** with default redirect semantics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c9f69932d187582764d32e06137ed841514dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->