### PR TITLE
fix(printables): resolve avatars via GraphQL

### DIFF
--- a/src/providers/printables.js
+++ b/src/providers/printables.js
@@ -1,13 +1,49 @@
 'use strict'
 
-const getAvatarUrl = input =>
-  `https://www.printables.com/${input.startsWith('@') ? input : `@${input}`}`
+const API_URL = 'https://api.printables.com/graphql/'
+const MEDIA_URL = 'https://media.printables.com'
 
-module.exports = ({ createHtmlProvider, getOgImage }) =>
-  createHtmlProvider({
-    name: 'printables',
-    url: getAvatarUrl,
-    getter: getOgImage
-  })
+const SEARCH_QUERY = `query SearchUsers($query: String!) {
+  result: searchUsers2(query: $query, limit: 10) {
+    items { handle avatarFilePath }
+  }
+}`
 
-module.exports.getAvatarUrl = getAvatarUrl
+const normalizeHandle = input =>
+  String(input || '')
+    .replace(/^@/, '')
+    .trim()
+
+const getAvatar = (body, handle) => {
+  const items = body?.data?.result?.items
+  if (!Array.isArray(items) || !handle) return
+
+  const user = items.find(
+    item => String(item?.handle || '').toLowerCase() === handle.toLowerCase()
+  )
+  const path = user?.avatarFilePath
+  if (!path) return
+
+  return `${MEDIA_URL}/${path.replace(/^\//, '')}`
+}
+
+module.exports = ({ got }) =>
+  async function printables (input) {
+    const handle = normalizeHandle(input)
+    if (!handle) return
+
+    const { body, statusCode } = await got(API_URL, {
+      method: 'POST',
+      responseType: 'json',
+      throwHttpErrors: false,
+      json: { query: SEARCH_QUERY, variables: { query: handle } },
+      headers: { origin: 'https://www.printables.com' }
+    })
+
+    if (statusCode >= 400) return
+
+    return getAvatar(body, handle)
+  }
+
+module.exports.getAvatar = getAvatar
+module.exports.normalizeHandle = normalizeHandle

--- a/src/providers/printables.js
+++ b/src/providers/printables.js
@@ -11,6 +11,7 @@ const SEARCH_QUERY = `query SearchUsers($query: String!) {
 
 const normalizeHandle = input =>
   String(input || '')
+    .trim()
     .replace(/^@/, '')
     .trim()
 

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -172,16 +172,6 @@ test('dribbble, reddit and telegram getters read expected HTML attributes', t =>
   t.is(telegram.getter(telegramHtml), 'https://a.com/tg.png')
 })
 
-test('printables provider prepends @ to input', t => {
-  const printables = require('../../../src/providers/printables')({
-    createHtmlProvider,
-    getOgImage
-  })
-
-  t.is(printables.url('DukeDoks'), 'https://www.printables.com/@DukeDoks')
-  t.is(printables.url('@DukeDoks'), 'https://www.printables.com/@DukeDoks')
-})
-
 test('soundcloud and substack provider options are derived from helper modules', t => {
   const soundcloud = proxyquire('../../../src/providers/soundcloud', {
     'unique-random-array': () => () => 'mobile-agent'

--- a/test/unit/providers/printables.js
+++ b/test/unit/providers/printables.js
@@ -24,6 +24,7 @@ const searchBody = {
 test('.normalizeHandle strips a leading @', t => {
   t.is(normalizeHandle('@DukeDoks'), 'DukeDoks')
   t.is(normalizeHandle('DukeDoks'), 'DukeDoks')
+  t.is(normalizeHandle(' @DukeDoks '), 'DukeDoks')
 })
 
 test('.getAvatar returns the media URL for an exact handle', t => {

--- a/test/unit/providers/printables.js
+++ b/test/unit/providers/printables.js
@@ -1,49 +1,85 @@
 'use strict'
 
-const cheerio = require('cheerio')
 const test = require('ava')
 
-const getOgImage = require('../../../src/util/get-og-image')
+const {
+  getAvatar,
+  normalizeHandle
+} = require('../../../src/providers/printables')
 
-const { getAvatarUrl } = require('../../../src/providers/printables')
+const createPrintables = got =>
+  require('../../../src/providers/printables')({ got })
 
-test('.getAvatarUrl prepends @ when missing', t => {
-  t.is(getAvatarUrl('kikobeats'), 'https://www.printables.com/@kikobeats')
+const avatarPath = 'media/auth/avatars/cd/cd02bb1d.jpg'
+const avatarUrl = `https://media.printables.com/${avatarPath}`
+
+const searchBody = {
+  data: {
+    result: {
+      items: [{ handle: 'DukeDoks', avatarFilePath: avatarPath }]
+    }
+  }
+}
+
+test('.normalizeHandle strips a leading @', t => {
+  t.is(normalizeHandle('@DukeDoks'), 'DukeDoks')
+  t.is(normalizeHandle('DukeDoks'), 'DukeDoks')
 })
 
-test('.getAvatarUrl keeps existing @ prefix', t => {
-  t.is(getAvatarUrl('@kikobeats'), 'https://www.printables.com/@kikobeats')
+test('.getAvatar returns the media URL for an exact handle', t => {
+  t.is(getAvatar(searchBody, 'DukeDoks'), avatarUrl)
 })
 
-const createHtmlProvider = opts => opts
-
-const printables = require('../../../src/providers/printables')({
-  createHtmlProvider,
-  getOgImage
+test('.getAvatar matches handle case-insensitively', t => {
+  t.is(getAvatar(searchBody, 'dukedoks'), avatarUrl)
 })
 
-test('getter extracts og:image from name attribute', t => {
-  const $ = cheerio.load(
-    '<html><head>' +
-      '<meta name="og:image" content="https://media.printables.com/media/auth/avatars/cd/thumbs/cover/320x320/jpg/cd02bb1d.jpg"/>' +
-      '</head></html>'
-  )
+test('.getAvatar ignores other search hits', t => {
   t.is(
-    printables.getter($),
-    'https://media.printables.com/media/auth/avatars/cd/thumbs/cover/320x320/jpg/cd02bb1d.jpg'
+    getAvatar(
+      {
+        data: {
+          result: {
+            items: [
+              { handle: 'Duke', avatarFilePath: 'media/other.jpg' },
+              { handle: 'DukeDoks', avatarFilePath: avatarPath }
+            ]
+          }
+        }
+      },
+      'DukeDoks'
+    ),
+    avatarUrl
   )
 })
 
-test('getter extracts og:image from property attribute', t => {
-  const $ = cheerio.load(
-    '<html><head>' +
-      '<meta property="og:image" content="https://media.printables.com/avatar.jpg"/>' +
-      '</head></html>'
+test('.getAvatar treats a missing avatar as a miss', t => {
+  t.is(getAvatar({ data: { result: { items: [] } } }, 'DukeDoks'), undefined)
+  t.is(
+    getAvatar(
+      { data: { result: { items: [{ handle: 'DukeDoks' }] } } },
+      'DukeDoks'
+    ),
+    undefined
   )
-  t.is(printables.getter($), 'https://media.printables.com/avatar.jpg')
 })
 
-test('getter returns undefined when og:image is missing', t => {
-  const $ = cheerio.load('<html><head></head><body></body></html>')
-  t.is(printables.getter($), undefined)
+test('printables resolves the avatar from GraphQL', async t => {
+  const printables = createPrintables(async (url, opts) => {
+    t.is(url, 'https://api.printables.com/graphql/')
+    t.is(opts.method, 'POST')
+    t.is(opts.json.variables.query, 'DukeDoks')
+    return { statusCode: 200, body: searchBody }
+  })
+
+  t.is(await printables('@DukeDoks'), avatarUrl)
+})
+
+test('printables returns undefined when the user is missing', async t => {
+  const printables = createPrintables(async () => ({
+    statusCode: 200,
+    body: { data: { result: { items: [] } } }
+  }))
+
+  t.is(await printables('missing'), undefined)
 })


### PR DESCRIPTION
## Summary
- Printables HTML profiles are behind a Cloudflare challenge, so `printables/DukeDoks` E2E returns `fallback.png`
- Resolve avatars through `api.printables.com/graphql` (`searchUsers2`) instead of scraping `og:image`

## Test plan
- [ ] `printables/DukeDoks` returns a `media.printables.com` avatar
- [ ] `printables/@DukeDoks` matches the same user
- [ ] Unknown handle falls through (no crash)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Printables avatars are now retrieved directly from profile data, improving accuracy and reliability.
  * Handle matching supports case-insensitive input and normalized handles.
* **Bug Fixes**
  * Invalid responses, missing users, unrelated results, and missing avatars are handled gracefully without disrupting avatar retrieval.
* **Tests**
  * Added coverage for avatar retrieval, handle normalization, matching behavior, request handling, and unsuccessful lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->