### PR TITLE
feat(providers): resolve Bluesky, Deezer, GitLab via API

### DIFF
--- a/src/providers/bluesky.js
+++ b/src/providers/bluesky.js
@@ -1,10 +1,25 @@
 'use strict'
 
-const { $jsonld } = require('@metascraper/helpers')
+const API_URL = 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile'
 
-module.exports = ({ createHtmlProvider }) =>
-  createHtmlProvider({
-    name: 'bluesky',
-    url: input => `https://bsky.app/profile/${input}`,
-    getter: $ => $jsonld('mainEntity.image')($)
-  })
+const getAvatarUrl = input => `${API_URL}?actor=${encodeURIComponent(input)}`
+
+const getAvatar = body => {
+  const pic = body?.avatar
+  return typeof pic === 'string' && pic ? pic : undefined
+}
+
+module.exports = ({ got }) =>
+  async function bluesky (input) {
+    const { body, statusCode } = await got(getAvatarUrl(input), {
+      responseType: 'json',
+      throwHttpErrors: false
+    })
+
+    if (statusCode >= 400) return
+
+    return getAvatar(body)
+  }
+
+module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/deezer.js
+++ b/src/providers/deezer.js
@@ -1,32 +1,44 @@
 'use strict'
 
+const API_URL = 'https://api.deezer.com'
+
 // Entities without artwork keep an empty image hash
 // (cdn-images.dzcdn.net/images/artist//500x500.jpg), which resolves to a
 // generic placeholder, so any empty hash segment is treated as a miss.
 const isArtwork = url => !/\/images\/[^/]+\/\/\d/.test(url)
 
-const getAvatarUrl = input => {
+const parseInput = input => {
   const [first, second] = input.split(':')
-  const type = second ? first : 'artist'
-  const id = second ?? first
-  return `https://www.deezer.com/en/${type}/${id}`
+  return {
+    type: second ? first : 'artist',
+    id: second ?? first
+  }
 }
 
-// Deezer server-renders og:image for missing entities as well, so the empty
-// placeholder is filtered out and everything else is returned as-is.
-const getAvatar = ({ $, getOgImage, NOT_FOUND }) => {
-  const image = getOgImage($)
-  return image && isArtwork(image) ? image : NOT_FOUND
+const getAvatarUrl = input => {
+  const { type, id } = parseInput(input)
+  return `${API_URL}/${encodeURIComponent(type)}/${encodeURIComponent(id)}`
 }
 
-const factory = ({ createHtmlProvider, getOgImage, NOT_FOUND }) =>
-  createHtmlProvider({
-    name: 'deezer',
-    url: getAvatarUrl,
-    getter: $ => getAvatar({ $, getOgImage, NOT_FOUND })
-  })
+const getAvatar = body => {
+  if (body?.error) return
 
-factory.getAvatarUrl = getAvatarUrl
-factory.getAvatar = getAvatar
+  const pic = body?.picture_xl || body?.cover_xl || body?.album?.cover_xl
+  return typeof pic === 'string' && pic && isArtwork(pic) ? pic : undefined
+}
 
-module.exports = factory
+module.exports = ({ got }) =>
+  async function deezer (input) {
+    const { body, statusCode } = await got(getAvatarUrl(input), {
+      responseType: 'json',
+      throwHttpErrors: false
+    })
+
+    if (statusCode >= 400) return
+
+    return getAvatar(body)
+  }
+
+module.exports.parseInput = parseInput
+module.exports.getAvatarUrl = getAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/src/providers/gitlab.js
+++ b/src/providers/gitlab.js
@@ -1,8 +1,43 @@
 'use strict'
 
-module.exports = ({ createHtmlProvider, getOgImage }) =>
-  createHtmlProvider({
-    name: 'gitlab',
-    url: input => `https://gitlab.com/${input}`,
-    getter: getOgImage
+const GITLAB_API_URL = 'https://gitlab.com/api/v4'
+
+const getUserAvatarUrl = input =>
+  `${GITLAB_API_URL}/users?username=${encodeURIComponent(input)}`
+
+const getGroupAvatarUrl = input =>
+  `${GITLAB_API_URL}/groups/${encodeURIComponent(input)}`
+
+const getAvatar = body => {
+  const pic = Array.isArray(body) ? body[0]?.avatar_url : body?.avatar_url
+  return typeof pic === 'string' && pic ? pic : undefined
+}
+
+const fetchAvatarUrl = async ({ got, url }) => {
+  const { statusCode, body } = await got(url, {
+    responseType: 'json',
+    throwHttpErrors: false
   })
+
+  if (statusCode >= 400) return
+
+  return getAvatar(body)
+}
+
+module.exports = ({ got }) =>
+  async function gitlab (input) {
+    const userAvatarUrl = await fetchAvatarUrl({
+      got,
+      url: getUserAvatarUrl(input)
+    })
+    if (userAvatarUrl) return userAvatarUrl
+
+    return fetchAvatarUrl({
+      got,
+      url: getGroupAvatarUrl(input)
+    })
+  }
+
+module.exports.getUserAvatarUrl = getUserAvatarUrl
+module.exports.getGroupAvatarUrl = getGroupAvatarUrl
+module.exports.getAvatar = getAvatar

--- a/test/unit/providers/bluesky.js
+++ b/test/unit/providers/bluesky.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const test = require('ava')
+
+const { getAvatar, getAvatarUrl } = require('../../../src/providers/bluesky')
+
+const createBluesky = got => require('../../../src/providers/bluesky')({ got })
+
+const avatarUrl =
+  'https://cdn.bsky.app/img/avatar/plain/did:plc:oky5czdrnfjpqslsw2a5iclo/bafkreihxtnc37g7jqdcgidtkknwuswtjiijcdnc6cx4imc4oq33cnsc5da'
+
+test('.getAvatarUrl builds the profile API URL', t => {
+  t.is(
+    getAvatarUrl('jay.bsky.team'),
+    'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=jay.bsky.team'
+  )
+})
+
+test('.getAvatarUrl encodes the actor', t => {
+  t.is(
+    getAvatarUrl('did:plc:oky5czdrnfjpqslsw2a5iclo'),
+    'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=did%3Aplc%3Aoky5czdrnfjpqslsw2a5iclo'
+  )
+})
+
+test('.getAvatar returns the avatar', t => {
+  t.is(getAvatar({ avatar: avatarUrl }), avatarUrl)
+})
+
+test('.getAvatar treats a missing or empty avatar as a miss', t => {
+  t.is(getAvatar({}), undefined)
+  t.is(getAvatar({ avatar: null }), undefined)
+  t.is(getAvatar({ avatar: '' }), undefined)
+})
+
+test('bluesky resolves the avatar from the profile API', async t => {
+  const bluesky = createBluesky(async (url, opts) => {
+    t.is(
+      url,
+      'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=jay.bsky.team'
+    )
+    t.is(opts.responseType, 'json')
+    t.false(opts.throwHttpErrors)
+
+    return { statusCode: 200, body: { avatar: avatarUrl } }
+  })
+
+  t.is(await bluesky('jay.bsky.team'), avatarUrl)
+})
+
+test('bluesky returns undefined when the actor is missing', async t => {
+  const bluesky = createBluesky(async () => ({
+    statusCode: 400,
+    body: { error: 'InvalidRequest', message: 'Profile not found' }
+  }))
+
+  t.is(await bluesky('missing.bsky.social'), undefined)
+})

--- a/test/unit/providers/deezer.js
+++ b/test/unit/providers/deezer.js
@@ -1,47 +1,86 @@
 'use strict'
 
 const test = require('ava')
-const cheerio = require('cheerio')
 
-const { getAvatar, getAvatarUrl } = require('../../../src/providers/deezer')
-const getOgImage = require('../../../src/util/get-og-image')
+const {
+  getAvatar,
+  getAvatarUrl,
+  parseInput
+} = require('../../../src/providers/deezer')
 
-const NOT_FOUND = Symbol('NOT_FOUND')
+const createDeezer = got => require('../../../src/providers/deezer')({ got })
 
-const avatarUrl =
-  'https://cdn-images.dzcdn.net/images/artist/638e69b9caaf9f9f3f8826febea7b543/500x500.jpg'
+const artistUrl =
+  'https://cdn-images.dzcdn.net/images/artist/638e69b9caaf9f9f3f8826febea7b543/1000x1000-000000-80-0-0.jpg'
+const coverUrl =
+  'https://cdn-images.dzcdn.net/images/cover/5718f7c81c27e0b2417e2a4c45224f8a/1000x1000-000000-80-0-0.jpg'
 
-const load = ogImage =>
-  cheerio.load(
-    `<html><head><meta property="og:image" content="${ogImage}"></head></html>`
-  )
-
-test('.getAvatarUrl defaults to artist profile path', t => {
-  t.is(getAvatarUrl('27'), 'https://www.deezer.com/en/artist/27')
+test('.parseInput defaults to artist', t => {
+  t.deepEqual(parseInput('27'), { type: 'artist', id: '27' })
 })
 
-test('.getAvatarUrl with explicit album type', t => {
-  t.is(getAvatarUrl('album:302127'), 'https://www.deezer.com/en/album/302127')
+test('.parseInput reads an explicit type', t => {
+  t.deepEqual(parseInput('album:302127'), { type: 'album', id: '302127' })
 })
 
-test('.getAvatarUrl with explicit playlist type', t => {
+test('.getAvatarUrl builds the artist API URL', t => {
+  t.is(getAvatarUrl('27'), 'https://api.deezer.com/artist/27')
+})
+
+test('.getAvatarUrl builds typed API URLs', t => {
+  t.is(getAvatarUrl('album:302127'), 'https://api.deezer.com/album/302127')
   t.is(
     getAvatarUrl('playlist:908622995'),
-    'https://www.deezer.com/en/playlist/908622995'
+    'https://api.deezer.com/playlist/908622995'
   )
+  t.is(getAvatarUrl('track:3135556'), 'https://api.deezer.com/track/3135556')
 })
 
-test('.getAvatar returns the og:image artwork', t => {
-  const $ = load(avatarUrl)
-  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), avatarUrl)
+test('.getAvatar returns picture_xl', t => {
+  t.is(getAvatar({ picture_xl: artistUrl }), artistUrl)
+})
+
+test('.getAvatar returns cover_xl for albums', t => {
+  t.is(getAvatar({ cover_xl: coverUrl }), coverUrl)
+})
+
+test('.getAvatar returns album cover_xl for tracks', t => {
+  t.is(getAvatar({ album: { cover_xl: coverUrl } }), coverUrl)
 })
 
 test('.getAvatar treats the empty-hash placeholder as a miss', t => {
-  const $ = load('https://cdn-images.dzcdn.net/images/artist//500x500.jpg')
-  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), NOT_FOUND)
+  t.is(
+    getAvatar({
+      picture_xl: 'https://cdn-images.dzcdn.net/images/artist//500x500.jpg'
+    }),
+    undefined
+  )
 })
 
-test('.getAvatar returns NOT_FOUND when there is no og:image', t => {
-  const $ = cheerio.load('<html><head></head></html>')
-  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), NOT_FOUND)
+test('.getAvatar treats an API error as a miss', t => {
+  t.is(
+    getAvatar({ error: { type: 'DataException', message: 'no data' } }),
+    undefined
+  )
+})
+
+test('deezer resolves the avatar from the artist API', async t => {
+  const deezer = createDeezer(async (url, opts) => {
+    t.is(url, 'https://api.deezer.com/artist/27')
+    t.is(opts.responseType, 'json')
+    t.false(opts.throwHttpErrors)
+
+    return { statusCode: 200, body: { picture_xl: artistUrl } }
+  })
+
+  t.is(await deezer('27'), artistUrl)
+})
+
+test('deezer returns undefined when the entity is missing', async t => {
+  const deezer = createDeezer(async () => ({
+    statusCode: 200,
+    body: { error: { type: 'DataException', message: 'no data' } }
+  }))
+
+  t.is(await deezer('0'), undefined)
 })

--- a/test/unit/providers/gitlab.js
+++ b/test/unit/providers/gitlab.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const test = require('ava')
+
+const {
+  getAvatar,
+  getGroupAvatarUrl,
+  getUserAvatarUrl
+} = require('../../../src/providers/gitlab')
+
+const createGitLab = got => require('../../../src/providers/gitlab')({ got })
+
+const userAvatarUrl =
+  'https://gitlab.com/uploads/-/system/user/avatar/493584/avatar.png'
+const groupAvatarUrl =
+  'https://gitlab.com/uploads/-/system/group/avatar/9970/project_avatar.png'
+
+test('.getUserAvatarUrl builds the users API URL', t => {
+  t.is(
+    getUserAvatarUrl('kikobeats'),
+    'https://gitlab.com/api/v4/users?username=kikobeats'
+  )
+})
+
+test('.getGroupAvatarUrl builds the groups API URL', t => {
+  t.is(
+    getGroupAvatarUrl('gitlab-org'),
+    'https://gitlab.com/api/v4/groups/gitlab-org'
+  )
+})
+
+test('.getAvatar returns avatar_url from a user list', t => {
+  t.is(getAvatar([{ avatar_url: userAvatarUrl }]), userAvatarUrl)
+})
+
+test('.getAvatar returns avatar_url from a group', t => {
+  t.is(getAvatar({ avatar_url: groupAvatarUrl }), groupAvatarUrl)
+})
+
+test('.getAvatar treats a missing or empty avatar_url as a miss', t => {
+  t.is(getAvatar([]), undefined)
+  t.is(getAvatar({}), undefined)
+  t.is(getAvatar({ avatar_url: '' }), undefined)
+})
+
+test('gitlab resolves the avatar from the users API', async t => {
+  const gitlab = createGitLab(async (url, opts) => {
+    t.is(url, 'https://gitlab.com/api/v4/users?username=kikobeats')
+    t.is(opts.responseType, 'json')
+    t.false(opts.throwHttpErrors)
+
+    return { statusCode: 200, body: [{ avatar_url: userAvatarUrl }] }
+  })
+
+  t.is(await gitlab('kikobeats'), userAvatarUrl)
+})
+
+test('gitlab falls back to the groups API', async t => {
+  let calls = 0
+  const gitlab = createGitLab(async url => {
+    calls += 1
+    if (url.includes('/users?')) {
+      return { statusCode: 200, body: [] }
+    }
+    t.is(url, 'https://gitlab.com/api/v4/groups/inkscape')
+    return { statusCode: 200, body: { avatar_url: groupAvatarUrl } }
+  })
+
+  t.is(await gitlab('inkscape'), groupAvatarUrl)
+  t.is(calls, 2)
+})
+
+test('gitlab returns undefined when user and group are missing', async t => {
+  const gitlab = createGitLab(async url => {
+    if (url.includes('/users?')) return { statusCode: 200, body: [] }
+    return { statusCode: 404, body: { message: '404 Group Not Found' } }
+  })
+
+  t.is(await gitlab('missing'), undefined)
+})

--- a/test/unit/providers/html-config.js
+++ b/test/unit/providers/html-config.js
@@ -15,17 +15,6 @@ test('html provider modules expose expected URL builders', t => {
   })
   t.is(behance.url('kikobeats'), 'https://www.behance.net/kikobeats')
 
-  const bluesky = proxyquire('../../../src/providers/bluesky', {
-    '@metascraper/helpers': {
-      $jsonld: path => () => `jsonld:${path}`
-    }
-  })({ createHtmlProvider })
-  t.is(
-    bluesky.url('kikobeats.bsky.social'),
-    'https://bsky.app/profile/kikobeats.bsky.social'
-  )
-  t.is(bluesky.getter({}), 'jsonld:mainEntity.image')
-
   const buymeacoffee = require('../../../src/providers/buymeacoffee')({
     createHtmlProvider
   })
@@ -66,12 +55,6 @@ test('html provider modules expose expected URL builders', t => {
     flickr.url('groups:best100only'),
     'https://www.flickr.com/groups/best100only/'
   )
-
-  const gitlab = require('../../../src/providers/gitlab')({
-    createHtmlProvider,
-    getOgImage
-  })
-  t.is(gitlab.url('kikobeats'), 'https://gitlab.com/kikobeats')
 
   const googlePlay = require('../../../src/providers/google-play')({
     createHtmlProvider,


### PR DESCRIPTION
## Summary
- Replace HTML scrapes with public JSON APIs for the three providers where that is a real win
- Bluesky: `app.bsky.actor.getProfile` → `avatar` (handles and DIDs)
- Deezer: `api.deezer.com/{type}/{id}` → `picture_xl` / `cover_xl` / track album cover; same `type:id` inputs; empty-hash placeholders still miss
- GitLab: users API first, then groups, so documented orgs (`inkscape`) still resolve

Left Tumblr, Vimeo, Steam, and Stack Overflow on HTML (302-only gain, deprecated API, XML scrape, or a 300/day quota).

## Test plan
- [x] `pnpm exec ava` on bluesky, gitlab, deezer, html-config, providers/index
- [x] `standard` on the touched files
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved avatar retrieval for Bluesky, Deezer, and GitLab by using their APIs.
  * Added support for more reliable artwork and avatar selection, including GitLab group fallbacks and Deezer cover images.
  * Improved handling of missing profiles, unavailable artwork, invalid inputs, and API errors.

* **Tests**
  * Added and updated automated coverage for avatar lookup, URL construction, fallbacks, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->