### PR TITLE
fix(providers): restore Deezer HTML and BMC script payload

### DIFF
--- a/src/providers/buymeacoffee.js
+++ b/src/providers/buymeacoffee.js
@@ -1,7 +1,10 @@
 'use strict'
 
+const getDataPage = $ =>
+  $('#app').attr('data-page') || $('script[data-page="app"]').html()
+
 const getAvatar = $ => {
-  const dataPage = $('#app').attr('data-page')
+  const dataPage = getDataPage($)
   if (!dataPage) return
 
   try {

--- a/src/providers/deezer.js
+++ b/src/providers/deezer.js
@@ -1,44 +1,32 @@
 'use strict'
 
-const API_URL = 'https://api.deezer.com'
-
 // Entities without artwork keep an empty image hash
 // (cdn-images.dzcdn.net/images/artist//500x500.jpg), which resolves to a
 // generic placeholder, so any empty hash segment is treated as a miss.
 const isArtwork = url => !/\/images\/[^/]+\/\/\d/.test(url)
 
-const parseInput = input => {
-  const [first, second] = input.split(':')
-  return {
-    type: second ? first : 'artist',
-    id: second ?? first
-  }
-}
-
 const getAvatarUrl = input => {
-  const { type, id } = parseInput(input)
-  return `${API_URL}/${encodeURIComponent(type)}/${encodeURIComponent(id)}`
+  const [first, second] = input.split(':')
+  const type = second ? first : 'artist'
+  const id = second ?? first
+  return `https://www.deezer.com/en/${type}/${id}`
 }
 
-const getAvatar = body => {
-  if (body?.error) return
-
-  const pic = body?.picture_xl || body?.cover_xl || body?.album?.cover_xl
-  return typeof pic === 'string' && pic && isArtwork(pic) ? pic : undefined
+// Deezer server-renders og:image for missing entities as well, so the empty
+// placeholder is filtered out and everything else is returned as-is.
+const getAvatar = ({ $, getOgImage, NOT_FOUND }) => {
+  const image = getOgImage($)
+  return image && isArtwork(image) ? image : NOT_FOUND
 }
 
-module.exports = ({ got }) =>
-  async function deezer (input) {
-    const { body, statusCode } = await got(getAvatarUrl(input), {
-      responseType: 'json',
-      throwHttpErrors: false
-    })
+const factory = ({ createHtmlProvider, getOgImage, NOT_FOUND }) =>
+  createHtmlProvider({
+    name: 'deezer',
+    url: getAvatarUrl,
+    getter: $ => getAvatar({ $, getOgImage, NOT_FOUND })
+  })
 
-    if (statusCode >= 400) return
+factory.getAvatarUrl = getAvatarUrl
+factory.getAvatar = getAvatar
 
-    return getAvatar(body)
-  }
-
-module.exports.parseInput = parseInput
-module.exports.getAvatarUrl = getAvatarUrl
-module.exports.getAvatar = getAvatar
+module.exports = factory

--- a/test/unit/providers/buymeacoffee.js
+++ b/test/unit/providers/buymeacoffee.js
@@ -44,6 +44,20 @@ test('.getAvatar falls back to regex extraction when data-page is not valid JSON
   t.is(getAvatar($), avatarUrl)
 })
 
+test('.getAvatar reads creator avatar from script[data-page=app]', t => {
+  const html = `
+    <html>
+      <body>
+        <div id="app"></div>
+        <script data-page="app" type="application/json">{"props":{"creator_data":{"data":{"dp":"${avatarUrl}"}}}}</script>
+      </body>
+    </html>
+  `
+
+  const $ = cheerio.load(html)
+  t.is(getAvatar($), avatarUrl)
+})
+
 test('.getAvatar returns undefined when data-page payload is missing', t => {
   const $ = cheerio.load('<html><body></body></html>')
   t.is(getAvatar($), undefined)

--- a/test/unit/providers/deezer.js
+++ b/test/unit/providers/deezer.js
@@ -1,86 +1,47 @@
 'use strict'
 
 const test = require('ava')
+const cheerio = require('cheerio')
 
-const {
-  getAvatar,
-  getAvatarUrl,
-  parseInput
-} = require('../../../src/providers/deezer')
+const { getAvatar, getAvatarUrl } = require('../../../src/providers/deezer')
+const getOgImage = require('../../../src/util/get-og-image')
 
-const createDeezer = got => require('../../../src/providers/deezer')({ got })
+const NOT_FOUND = Symbol('NOT_FOUND')
 
-const artistUrl =
-  'https://cdn-images.dzcdn.net/images/artist/638e69b9caaf9f9f3f8826febea7b543/1000x1000-000000-80-0-0.jpg'
-const coverUrl =
-  'https://cdn-images.dzcdn.net/images/cover/5718f7c81c27e0b2417e2a4c45224f8a/1000x1000-000000-80-0-0.jpg'
+const avatarUrl =
+  'https://cdn-images.dzcdn.net/images/artist/638e69b9caaf9f9f3f8826febea7b543/500x500.jpg'
 
-test('.parseInput defaults to artist', t => {
-  t.deepEqual(parseInput('27'), { type: 'artist', id: '27' })
+const load = ogImage =>
+  cheerio.load(
+    `<html><head><meta property="og:image" content="${ogImage}"></head></html>`
+  )
+
+test('.getAvatarUrl defaults to artist profile path', t => {
+  t.is(getAvatarUrl('27'), 'https://www.deezer.com/en/artist/27')
 })
 
-test('.parseInput reads an explicit type', t => {
-  t.deepEqual(parseInput('album:302127'), { type: 'album', id: '302127' })
+test('.getAvatarUrl with explicit album type', t => {
+  t.is(getAvatarUrl('album:302127'), 'https://www.deezer.com/en/album/302127')
 })
 
-test('.getAvatarUrl builds the artist API URL', t => {
-  t.is(getAvatarUrl('27'), 'https://api.deezer.com/artist/27')
-})
-
-test('.getAvatarUrl builds typed API URLs', t => {
-  t.is(getAvatarUrl('album:302127'), 'https://api.deezer.com/album/302127')
+test('.getAvatarUrl with explicit playlist type', t => {
   t.is(
     getAvatarUrl('playlist:908622995'),
-    'https://api.deezer.com/playlist/908622995'
+    'https://www.deezer.com/en/playlist/908622995'
   )
-  t.is(getAvatarUrl('track:3135556'), 'https://api.deezer.com/track/3135556')
 })
 
-test('.getAvatar returns picture_xl', t => {
-  t.is(getAvatar({ picture_xl: artistUrl }), artistUrl)
-})
-
-test('.getAvatar returns cover_xl for albums', t => {
-  t.is(getAvatar({ cover_xl: coverUrl }), coverUrl)
-})
-
-test('.getAvatar returns album cover_xl for tracks', t => {
-  t.is(getAvatar({ album: { cover_xl: coverUrl } }), coverUrl)
+test('.getAvatar returns the og:image artwork', t => {
+  const $ = load(avatarUrl)
+  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), avatarUrl)
 })
 
 test('.getAvatar treats the empty-hash placeholder as a miss', t => {
-  t.is(
-    getAvatar({
-      picture_xl: 'https://cdn-images.dzcdn.net/images/artist//500x500.jpg'
-    }),
-    undefined
-  )
+  const $ = load('https://cdn-images.dzcdn.net/images/artist//500x500.jpg')
+  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), NOT_FOUND)
 })
 
-test('.getAvatar treats an API error as a miss', t => {
-  t.is(
-    getAvatar({ error: { type: 'DataException', message: 'no data' } }),
-    undefined
-  )
-})
-
-test('deezer resolves the avatar from the artist API', async t => {
-  const deezer = createDeezer(async (url, opts) => {
-    t.is(url, 'https://api.deezer.com/artist/27')
-    t.is(opts.responseType, 'json')
-    t.false(opts.throwHttpErrors)
-
-    return { statusCode: 200, body: { picture_xl: artistUrl } }
-  })
-
-  t.is(await deezer('27'), artistUrl)
-})
-
-test('deezer returns undefined when the entity is missing', async t => {
-  const deezer = createDeezer(async () => ({
-    statusCode: 200,
-    body: { error: { type: 'DataException', message: 'no data' } }
-  }))
-
-  t.is(await deezer('0'), undefined)
+test('.getAvatar returns NOT_FOUND when there is no og:image', t => {
+  const $ = cheerio.load('<html><head></head></html>')
+  t.is(getAvatar({ $, getOgImage, NOT_FOUND }), NOT_FOUND)
 })


### PR DESCRIPTION
## Summary
- Closed: production pods can reach the Deezer API and artwork URLs, so this revert is not needed.